### PR TITLE
Add inventory-based route GUI and fix convoy start call

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/BetterTradeConvoys.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/BetterTradeConvoys.java
@@ -3,6 +3,7 @@ package me.luisgamedev.bettertradeconvoys;
 import me.luisgamedev.bettertradeconvoys.language.LanguageManager;
 import me.luisgamedev.bettertradeconvoys.listeners.CitizensListeners;
 import me.luisgamedev.bettertradeconvoys.listeners.DepositListener;
+import me.luisgamedev.bettertradeconvoys.listeners.RoutesGuiListener;
 import me.luisgamedev.bettertradeconvoys.service.ClaimStore;
 import me.luisgamedev.bettertradeconvoys.service.ConvoyManager;
 import me.luisgamedev.bettertradeconvoys.service.PlayerProgressStore;
@@ -45,6 +46,7 @@ public final class BetterTradeConvoys extends JavaPlugin {
 
         Bukkit.getPluginManager().registerEvents(new CitizensListeners(convoyManager, language, routesConfig), this);
         Bukkit.getPluginManager().registerEvents(new DepositListener(convoyManager), this);
+        Bukkit.getPluginManager().registerEvents(new RoutesGuiListener(convoyManager, language), this);
 
         if (getCommand("convoy") != null) {
             getCommand("convoy").setExecutor(new ConvoyCommand(this, convoyManager, routesConfig, claimStore, language));

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/commands/ConvoyStartCommand.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/commands/ConvoyStartCommand.java
@@ -5,8 +5,11 @@ import me.luisgamedev.bettertradeconvoys.model.RouteDefinition;
 import me.luisgamedev.bettertradeconvoys.model.TradeDefinition;
 import me.luisgamedev.bettertradeconvoys.service.ConvoyManager;
 import me.luisgamedev.bettertradeconvoys.service.RoutesConfig;
+import net.citizensnpcs.api.CitizensAPI;
+import net.citizensnpcs.api.npc.NPC;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -64,9 +67,14 @@ public class ConvoyStartCommand {
             return true;
         }
 
-        p.getInventory().setItemInMainHand(null);
+        Entity target = p.getTargetEntity(5);
+        NPC npc = target == null ? null : CitizensAPI.getNPCRegistry().getNPC(target);
+        if (npc == null) {
+            p.sendMessage("§cYou must look at an NPC to start a convoy.");
+            return true;
+        }
 
-        String result = convoyManager.startConvoy(p, routeId, matched, hand);
+        String result = convoyManager.startConvoy(p, npc, routeId, matched);
         p.sendMessage(result);
         return true;
     }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/listeners/RoutesGuiListener.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/listeners/RoutesGuiListener.java
@@ -1,0 +1,87 @@
+package me.luisgamedev.bettertradeconvoys.listeners;
+
+import me.luisgamedev.bettertradeconvoys.language.LanguageManager;
+import me.luisgamedev.bettertradeconvoys.model.RouteDefinition;
+import me.luisgamedev.bettertradeconvoys.model.TradeDefinition;
+import me.luisgamedev.bettertradeconvoys.service.ConvoyManager;
+import me.luisgamedev.bettertradeconvoys.service.ConvoyManager.RoutesGuiState;
+import net.citizensnpcs.api.npc.NPC;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class RoutesGuiListener implements Listener {
+
+    private final ConvoyManager manager;
+    private final LanguageManager lang;
+
+    public RoutesGuiListener(ConvoyManager manager, LanguageManager lang) {
+        this.manager = manager;
+        this.lang = lang;
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player p)) return;
+        RoutesGuiState state = manager.getRoutesGui(p.getUniqueId());
+        if (state == null) return;
+        if (!event.getView().getTitle().equals(ConvoyManager.ROUTES_GUI_TITLE)) return;
+        event.setCancelled(true);
+
+        int slot = event.getRawSlot();
+        if (slot == ConvoyManager.GUI_PREV_SLOT) {
+            if (state.getPage() > 0) {
+                state.setPage(state.getPage() - 1);
+                manager.renderRoutesGui(p, state);
+            }
+            return;
+        }
+        if (slot == ConvoyManager.GUI_NEXT_SLOT) {
+            if ((state.getPage() + 1) * ConvoyManager.GUI_PAGE_SIZE < state.getRoutes().size()) {
+                state.setPage(state.getPage() + 1);
+                manager.renderRoutesGui(p, state);
+            }
+            return;
+        }
+
+        if (!ConvoyManager.getRouteSlots().contains(slot)) return;
+
+        int indexInPage = ConvoyManager.getRouteSlots().indexOf(slot);
+        int routeIndex = state.getPage() * ConvoyManager.GUI_PAGE_SIZE + indexInPage;
+        if (routeIndex >= state.getRoutes().size()) return;
+
+        RouteDefinition rd = state.getRoutes().get(routeIndex);
+        if (rd.trades().isEmpty()) return;
+        TradeDefinition trade = rd.trades().get(0);
+        ItemStack need = trade.input().clone();
+        if (!p.getInventory().containsAtLeast(need, need.getAmount())) {
+            p.sendMessage(lang.format("deposit.wrong_item", lang.p("amount", need.getAmount(), "material", need.getType().name())));
+            return;
+        }
+
+        p.getInventory().removeItem(need.clone());
+        NPC npc = state.getNpc();
+        String result = manager.startConvoy(p, npc, rd.id(), trade);
+        p.sendMessage(result);
+        if (result.contains(ChatColor.RED.toString())) {
+            p.getInventory().addItem(need);
+            return;
+        }
+
+        var inst = manager.getActiveByOwner(p.getUniqueId());
+        if (inst != null) {
+            manager.onOwnerDeposited(p, npc, inst, need);
+        }
+        p.closeInventory();
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent event) {
+        manager.closeRoutesGui(event.getPlayer().getUniqueId());
+    }
+}
+

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -8,6 +8,7 @@ import net.citizensnpcs.api.ai.event.NavigationCompleteEvent;
 import net.citizensnpcs.api.npc.NPC;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
@@ -37,6 +38,29 @@ public class ConvoyManager {
     // Deposit-Flow
     private final Map<UUID, ItemStack> requiredInputByInstance = new HashMap<>();
     private final Map<UUID, Integer> depositProgressByInstance = new HashMap<>();
+
+    // GUI handling
+    public static final String ROUTES_GUI_TITLE = "Routes";
+    public static final int GUI_PREV_SLOT = 37;
+    public static final int GUI_NEXT_SLOT = 43;
+    private static final List<Integer> ROUTE_SLOTS;
+
+    static {
+        List<Integer> tmp = new ArrayList<>();
+        for (int row = 1; row <= 4; row++) {
+            for (int col = 1; col <= 7; col++) {
+                int slot = row * 9 + col;
+                if (slot == GUI_PREV_SLOT || slot == GUI_NEXT_SLOT) continue;
+                tmp.add(slot);
+            }
+        }
+        ROUTE_SLOTS = Collections.unmodifiableList(tmp);
+    }
+
+    public static List<Integer> getRouteSlots() { return ROUTE_SLOTS; }
+    public static final int GUI_PAGE_SIZE = ROUTE_SLOTS.size();
+
+    private final Map<UUID, RoutesGuiState> openRouteMenus = new HashMap<>();
 
     public ConvoyManager(BetterTradeConvoys plugin, RoutesConfig routes, PlayerProgressStore progress, ClaimStore claims, LanguageManager lang) {
         this.plugin = plugin;
@@ -482,6 +506,26 @@ public class ConvoyManager {
         }
     }
 
+    public RoutesGuiState getRoutesGui(UUID id) { return openRouteMenus.get(id); }
+    public void closeRoutesGui(UUID id) { openRouteMenus.remove(id); }
+
+    public static class RoutesGuiState {
+        private final NPC npc;
+        private final List<RouteDefinition> routes;
+        private int page;
+
+        public RoutesGuiState(NPC npc, List<RouteDefinition> routes) {
+            this.npc = npc;
+            this.routes = routes;
+            this.page = 0;
+        }
+
+        public NPC getNpc() { return npc; }
+        public List<RouteDefinition> getRoutes() { return routes; }
+        public int getPage() { return page; }
+        public void setPage(int page) { this.page = page; }
+    }
+
     // GUI-Einstieg – filtert Routen anhand npc-id und Permission
     public void openRoutesGui(Player p, NPC npc) {
         List<RouteDefinition> list = new ArrayList<>();
@@ -502,11 +546,65 @@ public class ConvoyManager {
             return;
         }
 
-        // TODO: Dein Inventar-GUI-Renderer; bis dahin einfache Textliste:
-        p.sendMessage("§6Available routes here:");
-        for (RouteDefinition r : list) {
-            p.sendMessage("§e- " + r.displayName() + " (§7id: " + r.id() + "§e)");
+        RoutesGuiState state = new RoutesGuiState(npc, list);
+        openRouteMenus.put(p.getUniqueId(), state);
+        renderRoutesGui(p, state);
+    }
+
+    public void renderRoutesGui(Player p, RoutesGuiState state) {
+        org.bukkit.inventory.Inventory inv = Bukkit.createInventory(null, 54, ROUTES_GUI_TITLE);
+
+        ItemStack glass = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
+        var gm = glass.getItemMeta();
+        if (gm != null) { gm.setDisplayName(" "); glass.setItemMeta(gm); }
+
+        for (int i = 0; i < inv.getSize(); i++) {
+            int row = i / 9;
+            int col = i % 9;
+            if (row == 0 || row == 5 || col == 0 || col == 8) {
+                inv.setItem(i, glass);
+            }
         }
-        p.sendMessage("§7Nutze /convoy start <routeId> während du diesen NPC ansiehst (oder GUI implementieren).");
+
+        int start = state.getPage() * GUI_PAGE_SIZE;
+        int end = Math.min(start + GUI_PAGE_SIZE, state.getRoutes().size());
+        for (int idx = start; idx < end; idx++) {
+            RouteDefinition r = state.getRoutes().get(idx);
+            ItemStack item;
+            if (!r.trades().isEmpty()) {
+                item = r.trades().get(0).input().clone();
+            } else {
+                item = new ItemStack(Material.PAPER);
+            }
+            var meta = item.getItemMeta();
+            if (meta != null) {
+                meta.setDisplayName("§e" + r.displayName());
+                List<String> lore = new ArrayList<>();
+                lore.add("§7ID: " + r.id());
+                if (!r.trades().isEmpty()) {
+                    ItemStack need = r.trades().get(0).input();
+                    lore.add("§7Needs: " + need.getAmount() + "x " + need.getType().name());
+                }
+                meta.setLore(lore);
+                item.setItemMeta(meta);
+            }
+            int slot = ROUTE_SLOTS.get(idx - start);
+            inv.setItem(slot, item);
+        }
+
+        if (state.getPage() > 0) {
+            ItemStack prev = new ItemStack(Material.ARROW);
+            var pm = prev.getItemMeta();
+            if (pm != null) { pm.setDisplayName("§ePrev"); prev.setItemMeta(pm); }
+            inv.setItem(GUI_PREV_SLOT, prev);
+        }
+        if ((state.getPage() + 1) * GUI_PAGE_SIZE < state.getRoutes().size()) {
+            ItemStack next = new ItemStack(Material.ARROW);
+            var nm = next.getItemMeta();
+            if (nm != null) { nm.setDisplayName("§eNext"); next.setItemMeta(nm); }
+            inv.setItem(GUI_NEXT_SLOT, next);
+        }
+
+        p.openInventory(inv);
     }
 }


### PR DESCRIPTION
## Summary
- Fix `/convoy start` to target clicked NPC and call manager with correct parameters
- Implement inventory-based route GUI with paging and automatic item deposit
- Register new GUI listener for handling route selection

## Testing
- `./gradlew build --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68b80af2a978832b98cf6082482814c6