### PR TITLE
Fix NPC not resuming after trade step

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -179,10 +179,8 @@ public class ConvoyManager {
     }
 
     private int findNextIndex(RouteDefinition rd, int from) {
-        for (int i = from + 1; i < rd.steps().size(); i++) {
-            if (rd.steps().get(i) instanceof WaypointStep) return i;
-        }
-        return -1;
+        int next = from + 1;
+        return next < rd.steps().size() ? next : -1;
     }
 
     private void navigateToCurrentStep(NPC npc, ConvoyInstance inst, RouteDefinition rd) {


### PR DESCRIPTION
## Summary
- process route steps sequentially so NPC resumes walking after trade delay

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68b858cab674832b800b49df1ab348d3