### PR TITLE
Add optional messages to route steps

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/RouteStep.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/RouteStep.java
@@ -1,3 +1,14 @@
 package me.luisgamedev.bettertradeconvoys.model;
 
-public interface RouteStep { }
+/**
+ * Represents a step in a trade route. Each step may optionally provide a
+ * message that will be sent to the route owner once the NPC reaches the step.
+ */
+public interface RouteStep {
+    /**
+     * Optional message that should be sent to the owner when this step is
+     * reached. Implementations may return {@code null} to indicate that no
+     * message should be sent.
+     */
+    String getMessage();
+}

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/TradeStep.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/TradeStep.java
@@ -1,5 +1,22 @@
 package me.luisgamedev.bettertradeconvoys.model;
 
-public enum TradeStep implements RouteStep {
-    INSTANCE
+/**
+ * Special step that represents a trading phase.
+ */
+public final class TradeStep implements RouteStep {
+    /**
+     * Shared instance used when no message is configured.
+     */
+    public static final TradeStep INSTANCE = new TradeStep(null);
+
+    private final String message;
+
+    public TradeStep(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
 }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/WaypointStep.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/WaypointStep.java
@@ -4,12 +4,26 @@ import org.bukkit.Location;
 
 public final class WaypointStep implements RouteStep {
     private final Location loc;
+    private final String message;
 
+    /**
+     * Creates a waypoint step without a message.
+     */
     public WaypointStep(Location loc) {
+        this(loc, null);
+    }
+
+    public WaypointStep(Location loc, String message) {
         this.loc = loc;
+        this.message = message;
     }
 
     public Location getLoc() {
         return loc;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
     }
 }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -187,8 +187,12 @@ public class ConvoyManager {
         if (step instanceof WaypointStep w) {
             npc.getNavigator().setTarget(w.getLoc());
         } else if (step instanceof TradeStep) {
+            sendStepMessage(inst, step);
             handleTradePauseThenNext(npc, inst, rd);
+            return;
         }
+        // For waypoint steps the message is sent once the NPC actually
+        // arrives at the location in onNavigationComplete.
     }
 
     private void handleTradePauseThenNext(NPC npc, ConvoyInstance inst, RouteDefinition rd) {
@@ -215,6 +219,9 @@ public class ConvoyManager {
 
         if (inst.getPhase() == ConvoyPhase.GOING_TO_DEST) {
             int cur = stepIndexByInstance.getOrDefault(inst.getInstanceId(), 0);
+            RouteStep step = rd.steps().get(cur);
+            sendStepMessage(inst, step);
+
             int next = findNextIndex(rd, cur);
             if (next == -1) {
                 onArrivedAtFinal(npc, inst, rd);
@@ -224,6 +231,15 @@ public class ConvoyManager {
             navigateToCurrentStep(npc, inst, rd);
         } else if (inst.getPhase() == ConvoyPhase.RETURNING) {
             onReturnedHome(npc, inst, rd);
+        }
+    }
+
+    private void sendStepMessage(ConvoyInstance inst, RouteStep step) {
+        String msg = step.getMessage();
+        if (msg == null || msg.isEmpty()) return;
+        Player owner = Bukkit.getPlayer(inst.getOwner());
+        if (owner != null) {
+            owner.sendMessage(msg);
         }
     }
 

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
@@ -55,14 +55,23 @@ public class RoutesConfig {
             if (rawSteps != null && !rawSteps.isEmpty()) {
                 for (Object o : rawSteps) {
                     if (o instanceof Map<?, ?> map) {
-                        double x = toDouble(map.get("x"), 0.0);
-                        double y = toDouble(map.get("y"), 64.0);
-                        double z = toDouble(map.get("z"), 0.0);
-                        Location loc = new Location(Bukkit.getWorld(worldName), x, y, z);
-                        steps.add(new WaypointStep(loc));
+                        if (map.containsKey("trade")) {
+                            String msg = map.containsKey("message") ? String.valueOf(map.get("message")) : null;
+                            steps.add(msg == null ? TradeStep.INSTANCE : new TradeStep(msg));
+                        } else {
+                            double x = toDouble(map.get("x"), 0.0);
+                            double y = toDouble(map.get("y"), 64.0);
+                            double z = toDouble(map.get("z"), 0.0);
+                            String msg = map.containsKey("message") ? String.valueOf(map.get("message")) : null;
+                            Location loc = new Location(Bukkit.getWorld(worldName), x, y, z);
+                            steps.add(new WaypointStep(loc, msg));
+                        }
                     } else if (o instanceof String s) {
-                        if ("trade".equalsIgnoreCase(s.trim())) steps.add(TradeStep.INSTANCE);
-                        else plugin.getLogger().warning("Unknown step string '" + s + "' in route '" + id + "'. Ignored.");
+                        if ("trade".equalsIgnoreCase(s.trim())) {
+                            steps.add(TradeStep.INSTANCE);
+                        } else {
+                            plugin.getLogger().warning("Unknown step string '" + s + "' in route '" + id + "'. Ignored.");
+                        }
                     } else {
                         plugin.getLogger().warning("Unsupported step entry in route '" + id + "': " + (o == null ? "null" : o.getClass().getName()));
                     }

--- a/BetterTradeConvoys/src/main/resources/routes.yml
+++ b/BetterTradeConvoys/src/main/resources/routes.yml
@@ -17,10 +17,10 @@ routes:
 
     # Steps/Waypoints that the NPC will walk
     steps:
-      - { x: 100.5, y: 64.0, z: -30.5 }   # Start/Spawn & Home-Pos
+      - { x: 100.5, y: 64.0, z: -30.5, message: "Let's start the run!" }   # Start/Spawn & Home-Pos
       - { x: 120.5, y: 64.0, z: -30.5 }
-      - trade
-      - { x: 140.5, y: 64.0, z: -15.5 }    # Last Waypoint = End & Claim-Spot
+      - { trade: true, message: "Time to trade." }
+      - { x: 140.5, y: 64.0, z: -15.5, message: "All done, heading back!" }    # Last Waypoint = End & Claim-Spot
 
     # Trade definition
     trades:


### PR DESCRIPTION
## Summary
- Allow defining messages for each waypoint and trade step in `routes.yml`
- Send the configured message to the route owner when the NPC reaches the step

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68b876307fe0832bb6c25a67715290b4