### PR TITLE
Colorize waypoint messages

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -6,6 +6,7 @@ import me.luisgamedev.bettertradeconvoys.model.*;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.npc.NPC;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -239,7 +240,7 @@ public class ConvoyManager {
         if (msg == null || msg.isEmpty()) return;
         Player owner = Bukkit.getPlayer(inst.getOwner());
         if (owner != null) {
-            owner.sendMessage(msg);
+            owner.sendMessage(ChatColor.translateAlternateColorCodes('&', msg));
         }
     }
 


### PR DESCRIPTION
## Summary
- translate `&` color codes in waypoint messages so they display with colors

## Testing
- `./gradlew build` *(fails: release version 21 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68b9583f4884832b9b5fc9a7dd3233b5