### PR TITLE
Allow selecting all routes in GUI

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/listeners/CitizensListeners.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/listeners/CitizensListeners.java
@@ -1,7 +1,6 @@
 package me.luisgamedev.bettertradeconvoys.listeners;
 
 import me.luisgamedev.bettertradeconvoys.language.LanguageManager;
-import me.luisgamedev.bettertradeconvoys.model.RouteDefinition;
 import me.luisgamedev.bettertradeconvoys.service.ConvoyManager;
 import me.luisgamedev.bettertradeconvoys.service.RoutesConfig;
 import net.citizensnpcs.api.ai.event.NavigationCompleteEvent;
@@ -46,8 +45,9 @@ public class CitizensListeners implements Listener {
             return;
         }
 
-        boolean offered = routes.getAll().values().stream().anyMatch(r -> r.npcIds().contains(npc.getId()));
-        if (!offered) return;
+        if (routes.getAll().isEmpty()) {
+            return;
+        }
 
         manager.openRoutesGui(event.getClicker(), npc);
     }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -78,10 +78,6 @@ public class ConvoyManager {
         RouteDefinition rd = routes.getRoute(routeId);
         if (rd == null) return lang.format("errors.unknown_route", lang.p("route", routeId));
 
-        if (!rd.npcIds().contains(npc.getId())) {
-            return lang.format("errors.route_locked_permission", lang.p("route", routeId));
-        }
-
         if (activeByNpcId.containsKey(npc.getId())) {
             return lang.get("errors.npc_busy");
         }
@@ -527,16 +523,12 @@ public class ConvoyManager {
     }
 
     public void openRoutesGui(Player p, NPC npc) {
-        List<RouteDefinition> list = new ArrayList<>();
-        for (var e : routes.getAll().values()) {
-            RouteDefinition r = e;
-            if (!r.npcIds().contains(npc.getId())) continue;
-
-            boolean allowedPerm = p.hasPermission("bettertradeconvoys.use");
-            if (!allowedPerm) continue;
-
-            list.add(r);
+        if (!p.hasPermission("bettertradeconvoys.use")) {
+            p.sendMessage(lang.get("errors.no_permission"));
+            return;
         }
+
+        List<RouteDefinition> list = new ArrayList<>(routes.getAll().values());
         if (list.isEmpty()) {
             p.sendMessage(lang.get("gui.no_routes_here"));
             return;

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
@@ -39,6 +39,10 @@ public class RoutesConfig {
             if (rs == null) continue;
 
             String idLower = id.toLowerCase(Locale.ROOT);
+            if (routes.containsKey(idLower)) {
+                plugin.getLogger().warning("Duplicate route id '" + id + "' found; skipping.");
+                continue;
+            }
             String display = rs.getString("display-name", id);
             String description = rs.getString("description", id);
             String worldName = rs.getString("waypoint-world", "world");

--- a/BetterTradeConvoys/src/main/resources/language.yml
+++ b/BetterTradeConvoys/src/main/resources/language.yml
@@ -30,7 +30,7 @@ npc:
   status_rightclick_owner: "&7Convoy phase: &e{phase}"
 
 gui:
-  no_routes_here: "&7No routes available at this NPC."
+  no_routes_here: "&7No routes available."
 
 deposit:
   progress: "&7Received &e{got}/{need}x {material}&7..."

--- a/BetterTradeConvoys/src/main/resources/routes.yml
+++ b/BetterTradeConvoys/src/main/resources/routes.yml
@@ -1,4 +1,5 @@
 routes:
+  # Route identifiers below must be unique
   # EXAMPLE ROUTE
   iron_to_diamond:
     # Name of the route
@@ -26,6 +27,62 @@ routes:
     trades:
       - input:  { material: IRON_INGOT, amount: 20 }
         output: { material: DIAMOND,    amount: 10 }
+
+    daily-limit: 3
+    weekly-limit: 10
+    monthly-limit: 40
+    cooldown-seconds: 3600
+
+  gold_to_netherite:
+    display-name: "Gold → Netherite Run"
+    description: "Trade gold for netherite"
+    npc-ids: [0, 1, 2]
+    waypoint-world: "world"
+
+    speed: 1
+    follow-radius: 10
+    expire-seconds: 900
+
+    announce-start: true
+    trade-delay-seconds: 8
+
+    steps:
+      - { x: 150.5, y: 64.0, z: -30.5 }
+      - { x: 170.5, y: 64.0, z: -30.5 }
+      - { trade: true, message: "Smelting into netherite..." }
+      - { x: 190.5, y: 64.0, z: -15.5, message: "Netherite ready!" }
+
+    trades:
+      - input:  { material: GOLD_INGOT, amount: 20 }
+        output: { material: NETHERITE_INGOT, amount: 1 }
+
+    daily-limit: 3
+    weekly-limit: 10
+    monthly-limit: 40
+    cooldown-seconds: 3600
+
+  coal_to_emerald:
+    display-name: "Coal → Emerald Run"
+    description: "Swap coal for emeralds"
+    npc-ids: [0, 1, 2]
+    waypoint-world: "world"
+
+    speed: 1
+    follow-radius: 10
+    expire-seconds: 900
+
+    announce-start: true
+    trade-delay-seconds: 8
+
+    steps:
+      - { x: 200.5, y: 64.0, z: -30.5 }
+      - { x: 220.5, y: 64.0, z: -30.5 }
+      - { trade: true, message: "Let me count those pieces." }
+      - { x: 240.5, y: 64.0, z: -15.5, message: "Here are your emeralds!" }
+
+    trades:
+      - input:  { material: COAL, amount: 32 }
+        output: { material: EMERALD, amount: 8 }
 
     daily-limit: 3
     weekly-limit: 10


### PR DESCRIPTION
## Summary
- allow starting any route from any NPC
- show all routes in the routes GUI
- adjust language to mention when no routes exist
- warn and skip duplicate route IDs so every uniquely named route appears
- include three distinct example routes in the default `routes.yml`

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68b97e810904832b8b93cfd3028b07cd