### PR TITLE
feat: add support for custom item plugins

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/CustomItemSupport.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/CustomItemSupport.java
@@ -1,0 +1,138 @@
+package me.luisgamedev.bettertradeconvoys.service;
+
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.ItemStack;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Utility for fetching custom items from supported item plugins.
+ * Uses reflection so that no hard dependencies are required at compile time.
+ */
+public final class CustomItemSupport {
+
+    private static final Map<String, Function<String, ItemStack>> PROVIDERS = new HashMap<>();
+
+    static {
+        registerOraxen();
+        registerItemsAdder();
+        registerNexo();
+        registerDivinity();
+        registerMMOCore();
+    }
+
+    private static void registerOraxen() {
+        if (!Bukkit.getPluginManager().isPluginEnabled("Oraxen")) return;
+        try {
+            Class<?> api = Class.forName("io.th0rgal.oraxen.api.OraxenItems");
+            Method get = api.getMethod("getItemById", String.class);
+            Method build = Class.forName("io.th0rgal.oraxen.items.OraxenItem").getMethod("build");
+            PROVIDERS.put("oraxen", id -> {
+                try {
+                    Object item = get.invoke(null, id);
+                    if (item == null) return null;
+                    return (ItemStack) build.invoke(item);
+                } catch (Exception e) {
+                    return null;
+                }
+            });
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static void registerItemsAdder() {
+        if (!Bukkit.getPluginManager().isPluginEnabled("ItemsAdder")) return;
+        try {
+            Class<?> api = Class.forName("dev.lone.itemsadder.api.CustomStack");
+            Method get = api.getMethod("getInstance", String.class);
+            Method stack = api.getMethod("getItemStack");
+            PROVIDERS.put("itemsadder", id -> {
+                try {
+                    Object obj = get.invoke(null, id);
+                    if (obj == null) return null;
+                    return (ItemStack) stack.invoke(obj);
+                } catch (Exception e) {
+                    return null;
+                }
+            });
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static void registerNexo() {
+        if (!Bukkit.getPluginManager().isPluginEnabled("Nexo")) return;
+        try {
+            Class<?> api = Class.forName("com.nexomc.nexo.api.NexoItems");
+            Method get = api.getMethod("getItem", String.class);
+            PROVIDERS.put("nexo", id -> {
+                try {
+                    Object result = get.invoke(null, id);
+                    if (result instanceof ItemStack is) return is;
+                    if (result != null) {
+                        Method build = result.getClass().getMethod("build");
+                        return (ItemStack) build.invoke(result);
+                    }
+                    return null;
+                } catch (Exception e) {
+                    return null;
+                }
+            });
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static void registerDivinity() {
+        if (!Bukkit.getPluginManager().isPluginEnabled("Divinity")) return;
+        try {
+            Class<?> api = Class.forName("me.swanis.divinity.api.DivinityAPI");
+            Method get = api.getMethod("getItem", String.class);
+            PROVIDERS.put("divinity", id -> {
+                try {
+                    Object result = get.invoke(null, id);
+                    if (result instanceof ItemStack is) return is;
+                    if (result != null) {
+                        Method toStack = result.getClass().getMethod("toItemStack");
+                        return (ItemStack) toStack.invoke(result);
+                    }
+                    return null;
+                } catch (Exception e) {
+                    return null;
+                }
+            });
+        } catch (Exception ignored) {
+        }
+    }
+
+    private static void registerMMOCore() {
+        if (!Bukkit.getPluginManager().isPluginEnabled("MMOCore")) return;
+        try {
+            Class<?> api = Class.forName("net.Indyuce.mmocore.api.item.ItemManager");
+            Object manager = api.getMethod("get").invoke(null);
+            Method getItem = api.getMethod("getItem", String.class);
+            Method toStack = Class.forName("io.lumine.mythic.lib.api.item.NBTItem").getMethod("toItem");
+            PROVIDERS.put("mmocore", id -> {
+                try {
+                    Object item = getItem.invoke(manager, id);
+                    if (item == null) return null;
+                    return (ItemStack) toStack.invoke(item);
+                } catch (Exception e) {
+                    return null;
+                }
+            });
+        } catch (Exception ignored) {
+        }
+    }
+
+    private CustomItemSupport() {
+    }
+
+    public static ItemStack getItem(String plugin, String id) {
+        Function<String, ItemStack> func = PROVIDERS.get(plugin.toLowerCase(Locale.ROOT));
+        return func != null ? func.apply(id) : null;
+    }
+}
+

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
@@ -95,15 +95,13 @@ public class RoutesConfig {
                     plugin.getLogger().warning("Invalid trade entry in route '" + id + "'. Skipping this trade.");
                     continue;
                 }
-                try {
-                    var inMat = Material.valueOf(String.valueOf(in.get("material")).toUpperCase(Locale.ROOT));
-                    int inAmt = toInt(in.get("amount"), 1);
-                    var outMat = Material.valueOf(String.valueOf(out.get("material")).toUpperCase(Locale.ROOT));
-                    int outAmt = toInt(out.get("amount"), 1);
-                    trades.add(new TradeDefinition(new ItemStack(inMat, inAmt), new ItemStack(outMat, outAmt)));
-                } catch (Exception ex) {
-                    plugin.getLogger().warning("Invalid trade materials in route '" + id + "': " + ex.getMessage());
+                ItemStack inStack = parseItem(in);
+                ItemStack outStack = parseItem(out);
+                if (inStack == null || outStack == null) {
+                    plugin.getLogger().warning("Invalid trade items in route '" + id + "'. Skipping this trade.");
+                    continue;
                 }
+                trades.add(new TradeDefinition(inStack, outStack));
             }
 
             int dailyLimit = rs.getInt("daily-limit", 0);
@@ -152,6 +150,33 @@ public class RoutesConfig {
 
     public Map<String, RouteDefinition> getAll() {
         return Collections.unmodifiableMap(routes);
+    }
+
+    private ItemStack parseItem(Map<?, ?> spec) {
+        if (spec.containsKey("material")) {
+            try {
+                Material mat = Material.valueOf(String.valueOf(spec.get("material")).toUpperCase(Locale.ROOT));
+                int amt = toInt(spec.get("amount"), 1);
+                return new ItemStack(mat, amt);
+            } catch (Exception ex) {
+                plugin.getLogger().warning("Invalid material '" + spec.get("material") + "': " + ex.getMessage());
+                return null;
+            }
+        }
+        if (spec.containsKey("plugin") && spec.containsKey("id")) {
+            String pluginName = String.valueOf(spec.get("plugin"));
+            String id = String.valueOf(spec.get("id"));
+            int amt = toInt(spec.get("amount"), 1);
+            ItemStack item = CustomItemSupport.getItem(pluginName, id);
+            if (item == null) {
+                plugin.getLogger().warning("Unknown custom item '" + id + "' for plugin '" + pluginName + "'");
+                return null;
+            }
+            item.setAmount(amt);
+            return item;
+        }
+        plugin.getLogger().warning("Invalid item specification: " + spec);
+        return null;
     }
 
     private static double toDouble(Object o, double def) {

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ If you have any questions or need help, feel free to join my Discord: https://di
   - Enable/disable global start announcements.  
   - Define waypoints and routes via coordinates.
 
-- 📦 **Trade System**  
-  - Define **input → output trades** per route.  
-  - Supports **custom items** from other plugins (Oraxen, MMOItems, etc.) via API hooks.  
+- 📦 **Trade System**
+  - Define **input → output trades** per route.
+  - Supports **custom items** from other plugins (Oraxen, Nexo, ItemsAdder, Divinity, MMOCore) via API hooks.
 
 - 🔒 **Persistent Data**  
   - Progress, cooldowns, and claims survive restarts.  
@@ -69,6 +69,10 @@ routes:
     trades:
       - input:  { material: IRON_INGOT, amount: 20 }
         output: { material: DIAMOND,    amount: 10 }
+
+      # Custom item example using Oraxen & ItemsAdder
+      - input:  { plugin: oraxen, id: custom_iron, amount: 5 }
+        output: { plugin: itemsadder, id: my_items:diamond_crate, amount: 1 }
 
     daily-limit: 3
     weekly-limit: 10


### PR DESCRIPTION
## Summary
- allow trades to use custom items from Oraxen, Nexo, ItemsAdder, Divinity and MMOCore
- load custom items during route parsing via new `CustomItemSupport`
- document custom item usage in README

## Testing
- `cd BetterTradeConvoys && ./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68bf08c6b590832bac83ff9946883aff