### PR TITLE
Respawn NPC at original location on death

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -327,7 +327,9 @@ public class ConvoyManager {
     public void onNpcDeath(NPC npc) {
         ConvoyInstance inst = activeByNpcId.get(npc.getId());
         if (inst == null) {
-            resetNpcHomeLocation(npc, npc.getStoredLocation());
+            Location home = npc.getStoredLocation();
+            resetNpcHomeLocation(npc, home);
+            respawnNpc(home, npc);
             return;
         }
 
@@ -338,14 +340,30 @@ public class ConvoyManager {
         }
 
         inst.setPhase(ConvoyPhase.FAILED);
+
+        Location home = homeByInstance.get(inst.getInstanceId());
         removeInstanceOnly(npc, inst);
 
         Player owner = Bukkit.getPlayer(inst.getOwner());
         if (owner != null) owner.sendMessage(lang.get("info.died_lost"));
 
-        Location home = homeByInstance.get(inst.getInstanceId());
         if (home == null) home = npc.getStoredLocation();
         resetNpcHomeLocation(npc, home);
+        respawnNpc(home, npc);
+    }
+
+    private void respawnNpc(Location home, NPC npc) {
+        try {
+            if (home != null && home.getWorld() != null) {
+                Location target = home.clone();
+                Bukkit.getScheduler().runTask(plugin, () -> {
+                    try {
+                        if (npc.isSpawned()) npc.despawn();
+                        npc.spawn(target);
+                    } catch (Exception ignored) { }
+                });
+            }
+        } catch (Exception ignored) { }
     }
 
     private void teleportNpcHome(NPC npc, ConvoyInstance inst) {


### PR DESCRIPTION
## Summary
- Respawn convoy NPCs at their stored starting location after death
- Capture home location before removing convoy instance to ensure proper return

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68bf1c408240832b94f22ef26f7d6dd4