### PR TITLE
Fix NPC respawn location to convoy start

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -112,7 +112,8 @@ public class ConvoyManager {
         for (int i = 0; i < rd.steps().size(); i++) {
             RouteStep s = rd.steps().get(i);
             if (s instanceof WaypointStep w) {
-                start = w.getLoc();
+                // clone to avoid Citizens mutating the original Location instance
+                start = w.getLoc().clone();
                 firstWpIdx = i;
                 break;
             }
@@ -123,7 +124,8 @@ public class ConvoyManager {
 
         try {
             if (npc.isSpawned()) npc.despawn();
-            npc.spawn(start);
+            // spawn with a clone so the stored home Location remains unchanged
+            npc.spawn(start.clone());
             npc.getNavigator().getDefaultParameters().speedModifier((float) rd.speed());
         } catch (Throwable ignored) {}
 
@@ -145,7 +147,8 @@ public class ConvoyManager {
         npc.data().setPersistent(META_INSTANCE, instanceId.toString());
         activeByNpcId.put(npc.getId(), inst);
         activeByInstance.put(instanceId, inst);
-        homeByInstance.put(instanceId, start);
+        // store a clone as the home location to ensure respawns use the original start point
+        homeByInstance.put(instanceId, start.clone());
 
         int nextIdx = findNextIndex(rd, firstWpIdx);
         if (nextIdx == -1) nextIdx = firstWpIdx;


### PR DESCRIPTION
## Summary
- clone NPC start location when initializing convoy
- spawn and store NPC home using cloned location to avoid mutation

## Testing
- `./gradlew build` *(fails: error: release version 21 not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1fdf48b4832bbd66a6cd51f03612