### PR TITLE
Add Vault money trade support

### DIFF
--- a/BetterTradeConvoys/build.gradle
+++ b/BetterTradeConvoys/build.gradle
@@ -16,12 +16,14 @@ repositories {
     mavenCentral()
     maven { url = 'https://repo.papermc.io/repository/maven-public/' }
     maven { url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
+    maven { url = 'https://jitpack.io' }
     flatDir { dirs 'libs' }
 }
 
 dependencies {
     compileOnly 'io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT'
     compileOnly name: 'Citizens-2.0.33-b3399'
+    compileOnly 'com.github.MilkBowl:VaultAPI:1.7'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/BetterTradeConvoys.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/BetterTradeConvoys.java
@@ -9,6 +9,8 @@ import me.luisgamedev.bettertradeconvoys.service.PlayerProgressStore;
 import me.luisgamedev.bettertradeconvoys.service.RoutesConfig;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.plugin.RegisteredServiceProvider;
 
 import java.io.File;
 
@@ -18,6 +20,7 @@ public final class BetterTradeConvoys extends JavaPlugin {
     private RoutesConfig routesConfig;
     private PlayerProgressStore progressStore;
     private ConvoyManager convoyManager;
+    private Economy economy;
 
     @Override
     public void onEnable() {
@@ -31,6 +34,8 @@ public final class BetterTradeConvoys extends JavaPlugin {
         language = new LanguageManager(this); language.load();
         routesConfig = new RoutesConfig(this); routesConfig.load();
         progressStore = new PlayerProgressStore(this); progressStore.load();
+
+        setupEconomy();
 
         convoyManager = new ConvoyManager(this, routesConfig, progressStore, language);
         convoyManager.initCitizensCheck();
@@ -76,5 +81,23 @@ public final class BetterTradeConvoys extends JavaPlugin {
 
     public ConvoyManager convoys() {
         return convoyManager;
+    }
+
+    public Economy economy() {
+        return economy;
+    }
+
+    private void setupEconomy() {
+        if (getServer().getPluginManager().getPlugin("Vault") == null) {
+            getLogger().warning("Vault not found. Money trades disabled.");
+            return;
+        }
+        RegisteredServiceProvider<Economy> rsp = getServer().getServicesManager().getRegistration(Economy.class);
+        if (rsp == null) {
+            getLogger().warning("No economy provider found. Money trades disabled.");
+            return;
+        }
+        economy = rsp.getProvider();
+        getLogger().info("Hooked into economy: " + economy.getName());
     }
 }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/listeners/CitizensListeners.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/listeners/CitizensListeners.java
@@ -31,7 +31,8 @@ public class CitizensListeners implements Listener {
     @EventHandler
     public void onNpcDeath(NPCDeathEvent event) {
         if (event.getNPC() == null) return;
-        manager.onNpcDeath(event.getNPC());
+        Player killer = event.getEvent() != null ? event.getEvent().getEntity().getKiller() : null;
+        manager.onNpcDeath(event.getNPC(), killer);
     }
 
     @EventHandler

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/listeners/RoutesGuiListener.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/listeners/RoutesGuiListener.java
@@ -57,24 +57,29 @@ public class RoutesGuiListener implements Listener {
         RouteDefinition rd = state.getRoutes().get(routeIndex);
         if (rd.trades().isEmpty()) return;
         TradeDefinition trade = rd.trades().get(0);
-        ItemStack need = trade.input().clone();
-        if (!p.getInventory().containsAtLeast(need, need.getAmount())) {
-            p.sendMessage(lang.format("deposit.wrong_item", lang.p("amount", need.getAmount(), "material", need.getType().name())));
-            return;
-        }
-
-        p.getInventory().removeItem(need.clone());
         NPC npc = state.getNpc();
-        String result = manager.startConvoy(p, npc, rd.id(), trade);
-        p.sendMessage(result);
-        if (result.contains(ChatColor.RED.toString())) {
-            p.getInventory().addItem(need);
-            return;
-        }
+        if (trade.inputItem() != null) {
+            ItemStack need = trade.inputItem().clone();
+            if (!p.getInventory().containsAtLeast(need, need.getAmount())) {
+                p.sendMessage(lang.format("deposit.wrong_item", lang.p("amount", need.getAmount(), "material", need.getType().name())));
+                return;
+            }
 
-        var inst = manager.getActiveByOwner(p.getUniqueId());
-        if (inst != null) {
-            manager.onOwnerDeposited(p, npc, inst, need);
+            p.getInventory().removeItem(need.clone());
+            String result = manager.startConvoy(p, npc, rd.id(), trade);
+            p.sendMessage(result);
+            if (result.contains(ChatColor.RED.toString())) {
+                p.getInventory().addItem(need);
+                return;
+            }
+
+            var inst = manager.getActiveByOwner(p.getUniqueId());
+            if (inst != null) {
+                manager.onOwnerDeposited(p, npc, inst, need);
+            }
+        } else {
+            String result = manager.startConvoy(p, npc, rd.id(), trade);
+            p.sendMessage(result);
         }
         p.closeInventory();
     }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/ConvoyInstance.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/ConvoyInstance.java
@@ -14,6 +14,8 @@ public class ConvoyInstance {
     private ConvoyPhase phase;
     private int waypointIndex;
     private List<ItemStack> carried;
+    private double carriedMoney;
+    private double investedMoney;
 
     private long startedAt;
 
@@ -26,6 +28,8 @@ public class ConvoyInstance {
         this.waypointIndex = waypointIndex;
         this.carried = carried;
         this.startedAt = startedAt;
+        this.carriedMoney = 0.0;
+        this.investedMoney = 0.0;
     }
 
     public UUID getInstanceId() { return instanceId; }
@@ -41,6 +45,12 @@ public class ConvoyInstance {
 
     public List<ItemStack> getCarried() { return carried; }
     public void setCarried(List<ItemStack> carried) { this.carried = carried; }
+
+    public double getCarriedMoney() { return carriedMoney; }
+    public void setCarriedMoney(double carriedMoney) { this.carriedMoney = carriedMoney; }
+
+    public double getInvestedMoney() { return investedMoney; }
+    public void setInvestedMoney(double investedMoney) { this.investedMoney = investedMoney; }
 
     public long getStartedAt() { return startedAt; }
 }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/TradeDefinition.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/TradeDefinition.java
@@ -3,6 +3,9 @@ package me.luisgamedev.bettertradeconvoys.model;
 import org.bukkit.inventory.ItemStack;
 
 public record TradeDefinition(
-        ItemStack input,
-        ItemStack output
-) { }
+        ItemStack inputItem,
+        ItemStack outputItem,
+        double inputMoney,
+        double outputMoney
+) {
+}

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -80,6 +80,15 @@ public class ConvoyManager {
 
         if (rd == null) return lang.format("errors.unknown_route", lang.p("route", rd.displayName()));
 
+        if ((trade.inputMoney() > 0 || trade.outputMoney() > 0) && plugin.economy() == null) {
+            return lang.get("errors.vault_missing");
+        }
+        if (trade.inputMoney() > 0 && plugin.economy() != null) {
+            if (!plugin.economy().has(owner, trade.inputMoney())) {
+                return lang.format("errors.not_enough_money", lang.p("amount", trade.inputMoney()));
+            }
+        }
+
         if (activeByNpcId.containsKey(npc.getId())) {
             return lang.get("errors.npc_busy");
         }
@@ -168,8 +177,17 @@ public class ConvoyManager {
         pausedByDistance.put(instanceId, false);
         waitingClaim.put(instanceId, false);
 
-        requiredInputByInstance.put(instanceId, trade.input().clone());
-        depositProgressByInstance.put(instanceId, 0);
+        if (trade.inputItem() != null) {
+            requiredInputByInstance.put(instanceId, trade.inputItem().clone());
+            depositProgressByInstance.put(instanceId, 0);
+        } else {
+            requiredInputByInstance.put(instanceId, null);
+            depositProgressByInstance.put(instanceId, 0);
+            if (trade.inputMoney() > 0 && plugin.economy() != null) {
+                plugin.economy().withdrawPlayer(owner, trade.inputMoney());
+                inst.setInvestedMoney(trade.inputMoney());
+            }
+        }
 
         if (rd.announceStart()) {
             Bukkit.broadcastMessage(lang.formatRaw("info.announced_start",
@@ -177,6 +195,9 @@ public class ConvoyManager {
         }
 
         startTicker(inst, npc, rd);
+        if (trade.inputItem() == null) {
+            navigateToCurrentStep(npc, inst, rd);
+        }
 
         progress.incStartsToday(owner.getUniqueId(), routeId);
         progress.incStartsThisWeek(owner.getUniqueId(), routeId);
@@ -279,17 +300,35 @@ public class ConvoyManager {
     private void exchangeAtDestination(ConvoyInstance inst, RouteDefinition rd) {
         if (inst.getPhase() != ConvoyPhase.GOING_TO_DEST) return;
         var carried = inst.getCarried();
-        if (carried.isEmpty()) { inst.setPhase(ConvoyPhase.EXCHANGED); return; }
-
-        ItemStack total = mergeStacks(carried);
-        for (TradeDefinition t : rd.trades()) {
-            if (t.input().getType() == total.getType() && t.input().getAmount() == total.getAmount()) {
-                inst.setCarried(Collections.singletonList(t.output().clone()));
-                inst.setPhase(ConvoyPhase.EXCHANGED);
-                return;
+        if (!carried.isEmpty()) {
+            ItemStack total = mergeStacks(carried);
+            for (TradeDefinition t : rd.trades()) {
+                if (t.inputItem() != null && t.inputItem().getType() == total.getType() && t.inputItem().getAmount() == total.getAmount()) {
+                    if (t.outputItem() != null) {
+                        inst.setCarried(Collections.singletonList(t.outputItem().clone()));
+                    } else if (t.outputMoney() > 0) {
+                        inst.setCarried(Collections.emptyList());
+                        inst.setCarriedMoney(t.outputMoney());
+                    }
+                    inst.setPhase(ConvoyPhase.EXCHANGED);
+                    return;
+                }
             }
+            inst.setPhase(ConvoyPhase.EXCHANGED);
+        } else {
+            for (TradeDefinition t : rd.trades()) {
+                if (t.inputMoney() > 0) {
+                    if (t.outputItem() != null) {
+                        inst.setCarried(Collections.singletonList(t.outputItem().clone()));
+                    } else if (t.outputMoney() > 0) {
+                        inst.setCarriedMoney(t.outputMoney());
+                    }
+                    inst.setPhase(ConvoyPhase.EXCHANGED);
+                    return;
+                }
+            }
+            inst.setPhase(ConvoyPhase.EXCHANGED);
         }
-        inst.setPhase(ConvoyPhase.EXCHANGED);
     }
 
     private ItemStack mergeStacks(List<ItemStack> list) {
@@ -315,6 +354,10 @@ public class ConvoyManager {
             return;
         }
 
+        if (plugin.economy() != null && inst.getCarriedMoney() > 0) {
+            plugin.economy().depositPlayer(p, inst.getCarriedMoney());
+            inst.setCarriedMoney(0);
+        }
         giveOrDrop(p, inst.getCarried());
         p.sendMessage(lang.get("info.claimed"));
 
@@ -324,6 +367,10 @@ public class ConvoyManager {
 
     private void onReturnedHome(NPC npc, ConvoyInstance inst, RouteDefinition rd) {
         Player owner = Bukkit.getPlayer(inst.getOwner());
+        if (plugin.economy() != null && inst.getCarriedMoney() > 0) {
+            plugin.economy().depositPlayer(owner != null ? owner : Bukkit.getOfflinePlayer(inst.getOwner()), inst.getCarriedMoney());
+            inst.setCarriedMoney(0);
+        }
         if (owner != null) {
             giveOrDrop(owner, inst.getCarried());
             owner.sendMessage(lang.format("info.completed_ready", lang.p("name", rd.displayName())));
@@ -338,7 +385,7 @@ public class ConvoyManager {
         removeInstanceOnly(npc, inst);
     }
 
-    public void onNpcDeath(NPC npc) {
+    public void onNpcDeath(NPC npc, Player killer) {
         ConvoyInstance inst = activeByNpcId.get(npc.getId());
         if (inst == null) {
             Location home = npc.getStoredLocation();
@@ -351,6 +398,11 @@ public class ConvoyManager {
         for (ItemStack it : inst.getCarried()) {
             if (it == null) continue;
             loc.getWorld().dropItemNaturally(loc, it.clone());
+        }
+
+        if (plugin.economy() != null && killer != null && inst.getInvestedMoney() > 0) {
+            plugin.economy().depositPlayer(killer, inst.getInvestedMoney());
+            inst.setInvestedMoney(0);
         }
 
         inst.setPhase(ConvoyPhase.FAILED);
@@ -497,14 +549,25 @@ public class ConvoyManager {
 
     private List<ItemStack> refundInput(ConvoyInstance inst, RouteDefinition rd) {
         var carried = inst.getCarried();
-        if (carried.isEmpty()) return Collections.emptyList();
-        var first = carried.get(0);
-        for (TradeDefinition t : rd.trades()) {
-            if (t.output().getType() == first.getType() && t.output().getAmount() == first.getAmount()) {
-                return Collections.singletonList(t.input().clone());
+        if (!carried.isEmpty()) {
+            var first = carried.get(0);
+            for (TradeDefinition t : rd.trades()) {
+                if (t.outputItem() != null && t.outputItem().getType() == first.getType() && t.outputItem().getAmount() == first.getAmount()) {
+                    if (t.inputItem() != null) {
+                        return Collections.singletonList(t.inputItem().clone());
+                    } else if (t.inputMoney() > 0 && plugin.economy() != null) {
+                        plugin.economy().depositPlayer(Bukkit.getOfflinePlayer(inst.getOwner()), t.inputMoney());
+                        return Collections.emptyList();
+                    }
+                }
             }
+            return new ArrayList<>(carried);
+        } else {
+            if (inst.getInvestedMoney() > 0 && plugin.economy() != null) {
+                plugin.economy().depositPlayer(Bukkit.getOfflinePlayer(inst.getOwner()), inst.getInvestedMoney());
+            }
+            return Collections.emptyList();
         }
-        return new ArrayList<>(carried);
     }
 
     private void giveOrDrop(Player p, List<ItemStack> items) {
@@ -600,9 +663,16 @@ public class ConvoyManager {
         int end = Math.min(start + GUI_PAGE_SIZE, state.getRoutes().size());
         for (int idx = start; idx < end; idx++) {
             RouteDefinition r = state.getRoutes().get(idx);
+            TradeDefinition t = !r.trades().isEmpty() ? r.trades().get(0) : null;
             ItemStack item;
-            if (!r.trades().isEmpty()) {
-                item = r.trades().get(0).input().clone();
+            if (t != null) {
+                if (t.inputItem() != null) {
+                    item = t.inputItem().clone();
+                } else if (t.outputItem() != null) {
+                    item = t.outputItem().clone();
+                } else {
+                    item = new ItemStack(Material.PAPER);
+                }
             } else {
                 item = new ItemStack(Material.PAPER);
             }
@@ -611,9 +681,13 @@ public class ConvoyManager {
                 meta.setDisplayName("§e" + r.displayName());
                 List<String> lore = new ArrayList<>();
                 lore.add("§7" + r.description());
-                if (!r.trades().isEmpty()) {
-                    ItemStack need = r.trades().get(0).input();
-                    lore.add("§7Needs: " + need.getAmount() + "x " + need.getType().name());
+                if (t != null) {
+                    if (t.inputItem() != null) {
+                        ItemStack need = t.inputItem();
+                        lore.add("§7Needs: " + need.getAmount() + "x " + need.getType().name());
+                    } else if (t.inputMoney() > 0) {
+                        lore.add("§7Needs: $" + t.inputMoney());
+                    }
                 }
                 meta.setLore(lore);
                 item.setItemMeta(meta);

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
@@ -95,13 +95,25 @@ public class RoutesConfig {
                     plugin.getLogger().warning("Invalid trade entry in route '" + id + "'. Skipping this trade.");
                     continue;
                 }
-                ItemStack inStack = parseItem(in);
-                ItemStack outStack = parseItem(out);
-                if (inStack == null || outStack == null) {
+                ItemStack inStack = null;
+                double inMoney = 0.0;
+                if (in.containsKey("money")) {
+                    inMoney = toDouble(in.get("money"), 0.0);
+                } else {
+                    inStack = parseItem(in);
+                }
+                ItemStack outStack = null;
+                double outMoney = 0.0;
+                if (out.containsKey("money")) {
+                    outMoney = toDouble(out.get("money"), 0.0);
+                } else {
+                    outStack = parseItem(out);
+                }
+                if ((inStack == null && inMoney <= 0) || (outStack == null && outMoney <= 0)) {
                     plugin.getLogger().warning("Invalid trade items in route '" + id + "'. Skipping this trade.");
                     continue;
                 }
-                trades.add(new TradeDefinition(inStack, outStack));
+                trades.add(new TradeDefinition(inStack, outStack, inMoney, outMoney));
             }
 
             int dailyLimit = rs.getInt("daily-limit", 0);

--- a/BetterTradeConvoys/src/main/resources/language.yml
+++ b/BetterTradeConvoys/src/main/resources/language.yml
@@ -13,6 +13,8 @@ errors:
   no_permission: "&cYou do not have permission to do that."
   invalid_hand_item: "&cHold the required item in your main hand."
   no_matching_trade: "&cNo matching trade for this item."
+  vault_missing: "&cVault with economy plugin is required for money trades."
+  not_enough_money: "&cYou need &e{amount}&c to start this route."
 
 info:
   started: "&aAll items received. Convoy starts!"

--- a/BetterTradeConvoys/src/main/resources/plugin.yml
+++ b/BetterTradeConvoys/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: me.luisgamedev.bettertradeconvoys.BetterTradeConvoys
 version: 1.0
 api-version: '1.20'
 website: 'https://github.com/Luis-GameDev'
-softdepend: [ Citizens ]
+softdepend: [ Citizens, Vault ]
 
 permissions:
   bettertradeconvoys.use:


### PR DESCRIPTION
## Summary
- integrate Vault economy to enable money-based trades
- allow routes to define monetary inputs and outputs
- display money requirements in route GUI and process payouts
- pay the NPC's killer any invested money when a convoy is slain

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68bf26f63ab0832b888339cc72526886