### PR TITLE
Fix NPC respawn after death on route

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -6,6 +6,7 @@ import me.luisgamedev.bettertradeconvoys.model.*;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.trait.CurrentLocation;
+import net.citizensnpcs.api.event.DespawnReason;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -386,6 +387,8 @@ public class ConvoyManager {
     }
 
     public void onNpcDeath(NPC npc, Player killer) {
+        try { npc.despawn(DespawnReason.DEATH); } catch (Exception ignored) { }
+
         ConvoyInstance inst = activeByNpcId.get(npc.getId());
         if (inst == null) {
             Location home = npc.getStoredLocation();
@@ -422,12 +425,12 @@ public class ConvoyManager {
         try {
             if (home != null && home.getWorld() != null) {
                 Location target = home.clone();
-                Bukkit.getScheduler().runTask(plugin, () -> {
+                Bukkit.getScheduler().runTaskLater(plugin, () -> {
                     try {
-                        if (npc.isSpawned()) npc.despawn();
+                        if (npc.isSpawned()) npc.despawn(DespawnReason.PLUGIN);
                         npc.spawn(target);
                     } catch (Exception ignored) { }
-                });
+                }, 20L);
             }
         } catch (Exception ignored) { }
     }


### PR DESCRIPTION
## Summary
- Despawn Citizens NPC on death and delay respawn to avoid duplicate UUIDs
- Respawn NPC at recorded home location after short delay

## Testing
- `cd BetterTradeConvoys && ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68bf3b6ad2e8832bb7ef11a61a3ad184