### PR TITLE
Prevent double despawn on NPC death

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -393,8 +393,6 @@ public class ConvoyManager {
     }
 
     public void onNpcDeath(NPC npc, Player killer) {
-        try { npc.despawn(DespawnReason.DEATH); } catch (Exception ignored) { }
-
         ConvoyInstance inst = activeByNpcId.get(npc.getId());
         if (inst == null) {
             Location home = npc.getStoredLocation();


### PR DESCRIPTION
## Summary
- Avoid manually despawning Citizens NPCs on death to let Citizens handle cleanup
- Keeps NPC respawn logic intact without triggering NPE in PlayerDeathEvent

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68bf407e74cc832bb2f0a6f597ca508b