### PR TITLE
Add configurable GUI layouts via gui.yml

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/BetterTradeConvoys.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/BetterTradeConvoys.java
@@ -7,6 +7,7 @@ import me.luisgamedev.bettertradeconvoys.listeners.RoutesGuiListener;
 import me.luisgamedev.bettertradeconvoys.service.ConvoyManager;
 import me.luisgamedev.bettertradeconvoys.service.PlayerProgressStore;
 import me.luisgamedev.bettertradeconvoys.service.RoutesConfig;
+import me.luisgamedev.bettertradeconvoys.service.GuiConfig;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import net.milkbowl.vault.economy.Economy;
@@ -19,6 +20,7 @@ public final class BetterTradeConvoys extends JavaPlugin {
     private LanguageManager language;
     private RoutesConfig routesConfig;
     private PlayerProgressStore progressStore;
+    private GuiConfig guiConfig;
     private ConvoyManager convoyManager;
     private Economy economy;
 
@@ -30,14 +32,16 @@ public final class BetterTradeConvoys extends JavaPlugin {
 
         saveDefaultIfMissing("routes.yml");
         saveDefaultIfMissing("language.yml");
+        saveDefaultIfMissing("gui.yml");
 
         language = new LanguageManager(this); language.load();
         routesConfig = new RoutesConfig(this); routesConfig.load();
         progressStore = new PlayerProgressStore(this); progressStore.load();
+        guiConfig = new GuiConfig(this); guiConfig.load();
 
         setupEconomy();
 
-        convoyManager = new ConvoyManager(this, routesConfig, progressStore, language);
+        convoyManager = new ConvoyManager(this, routesConfig, progressStore, guiConfig, language);
         convoyManager.initCitizensCheck();
 
         Bukkit.getPluginManager().registerEvents(new CitizensListeners(convoyManager, language, routesConfig), this);

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/listeners/RoutesGuiListener.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/listeners/RoutesGuiListener.java
@@ -29,29 +29,30 @@ public class RoutesGuiListener implements Listener {
         if (!(event.getWhoClicked() instanceof Player p)) return;
         RoutesGuiState state = manager.getRoutesGui(p.getUniqueId());
         if (state == null) return;
-        if (!event.getView().getTitle().equals(ConvoyManager.ROUTES_GUI_TITLE)) return;
+        if (!event.getView().getTitle().equals(state.getLayout().title())) return;
         event.setCancelled(true);
 
         int slot = event.getRawSlot();
-        if (slot == ConvoyManager.GUI_PREV_SLOT) {
+        if (slot == state.getLayout().prevSlot()) {
             if (state.getPage() > 0) {
                 state.setPage(state.getPage() - 1);
                 manager.renderRoutesGui(p, state);
             }
             return;
         }
-        if (slot == ConvoyManager.GUI_NEXT_SLOT) {
-            if ((state.getPage() + 1) * ConvoyManager.GUI_PAGE_SIZE < state.getRoutes().size()) {
+        int pageSize = state.getLayout().routeSlots().size();
+        if (slot == state.getLayout().nextSlot()) {
+            if ((state.getPage() + 1) * pageSize < state.getRoutes().size()) {
                 state.setPage(state.getPage() + 1);
                 manager.renderRoutesGui(p, state);
             }
             return;
         }
 
-        if (!ConvoyManager.getRouteSlots().contains(slot)) return;
+        if (!state.getLayout().routeSlots().contains(slot)) return;
 
-        int indexInPage = ConvoyManager.getRouteSlots().indexOf(slot);
-        int routeIndex = state.getPage() * ConvoyManager.GUI_PAGE_SIZE + indexInPage;
+        int indexInPage = state.getLayout().routeSlots().indexOf(slot);
+        int routeIndex = state.getPage() * pageSize + indexInPage;
         if (routeIndex >= state.getRoutes().size()) return;
 
         RouteDefinition rd = state.getRoutes().get(routeIndex);

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/RouteDefinition.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/RouteDefinition.java
@@ -19,5 +19,6 @@ public record RouteDefinition(
         int expireSeconds,
         int tradeDelaySeconds,
         boolean announceStart,
+        String guiLayout,
         Set<Integer> npcIds
 ) { }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -25,6 +25,7 @@ public class ConvoyManager {
     private final RoutesConfig routes;
     private final PlayerProgressStore progress;
     private final LanguageManager lang;
+    private final GuiConfig guiConfig;
 
     private final Map<Integer, ConvoyInstance> activeByNpcId = new HashMap<>();
     private final Map<UUID, ConvoyInstance> activeByInstance = new HashMap<>();
@@ -41,33 +42,15 @@ public class ConvoyManager {
     private final Map<UUID, Integer> depositProgressByInstance = new HashMap<>();
 
     // GUI handling
-    public static final String ROUTES_GUI_TITLE = "Routes";
-    public static final int GUI_PREV_SLOT = 37;
-    public static final int GUI_NEXT_SLOT = 43;
-    private static final List<Integer> ROUTE_SLOTS;
-
-    static {
-        List<Integer> tmp = new ArrayList<>();
-        for (int row = 1; row <= 4; row++) {
-            for (int col = 1; col <= 7; col++) {
-                int slot = row * 9 + col;
-                if (slot == GUI_PREV_SLOT || slot == GUI_NEXT_SLOT) continue;
-                tmp.add(slot);
-            }
-        }
-        ROUTE_SLOTS = Collections.unmodifiableList(tmp);
-    }
-
-    public static List<Integer> getRouteSlots() { return ROUTE_SLOTS; }
-    public static final int GUI_PAGE_SIZE = ROUTE_SLOTS.size();
 
     private final Map<UUID, RoutesGuiState> openRouteMenus = new HashMap<>();
 
-    public ConvoyManager(BetterTradeConvoys plugin, RoutesConfig routes, PlayerProgressStore progress, LanguageManager lang) {
+    public ConvoyManager(BetterTradeConvoys plugin, RoutesConfig routes, PlayerProgressStore progress, GuiConfig guiConfig, LanguageManager lang) {
         this.plugin = plugin;
         this.routes = routes;
         this.progress = progress;
         this.lang = lang;
+        this.guiConfig = guiConfig;
     }
 
     public void initCitizensCheck() {
@@ -632,16 +615,19 @@ public class ConvoyManager {
     public static class RoutesGuiState {
         private final NPC npc;
         private final List<RouteDefinition> routes;
+        private final GuiConfig.GuiLayout layout;
         private int page;
 
-        public RoutesGuiState(NPC npc, List<RouteDefinition> routes) {
+        public RoutesGuiState(NPC npc, List<RouteDefinition> routes, GuiConfig.GuiLayout layout) {
             this.npc = npc;
             this.routes = routes;
+            this.layout = layout;
             this.page = 0;
         }
 
         public NPC getNpc() { return npc; }
         public List<RouteDefinition> getRoutes() { return routes; }
+        public GuiConfig.GuiLayout getLayout() { return layout; }
         public int getPage() { return page; }
         public void setPage(int page) { this.page = page; }
     }
@@ -662,28 +648,31 @@ public class ConvoyManager {
             return;
         }
 
-        RoutesGuiState state = new RoutesGuiState(npc, list);
+        String layoutId = !list.isEmpty() ? list.get(0).guiLayout() : "default";
+        GuiConfig.GuiLayout layout = guiConfig.getLayoutOrDefault(layoutId);
+        if (layout == null) return;
+        RoutesGuiState state = new RoutesGuiState(npc, list, layout);
         openRouteMenus.put(p.getUniqueId(), state);
         renderRoutesGui(p, state);
     }
 
     public void renderRoutesGui(Player p, RoutesGuiState state) {
-        org.bukkit.inventory.Inventory inv = Bukkit.createInventory(null, 54, ROUTES_GUI_TITLE);
+        GuiConfig.GuiLayout layout = state.getLayout();
+        org.bukkit.inventory.Inventory inv = Bukkit.createInventory(null, layout.size(), layout.title());
 
-        ItemStack glass = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
-        var gm = glass.getItemMeta();
-        if (gm != null) { gm.setDisplayName(" "); glass.setItemMeta(gm); }
+        ItemStack glass = layout.borderItem().clone();
 
         for (int i = 0; i < inv.getSize(); i++) {
             int row = i / 9;
             int col = i % 9;
-            if (row == 0 || row == 5 || col == 0 || col == 8) {
+            if (row == 0 || row == (inv.getSize() / 9) - 1 || col == 0 || col == 8) {
                 inv.setItem(i, glass);
             }
         }
 
-        int start = state.getPage() * GUI_PAGE_SIZE;
-        int end = Math.min(start + GUI_PAGE_SIZE, state.getRoutes().size());
+        int pageSize = layout.routeSlots().size();
+        int start = state.getPage() * pageSize;
+        int end = Math.min(start + pageSize, state.getRoutes().size());
         for (int idx = start; idx < end; idx++) {
             RouteDefinition r = state.getRoutes().get(idx);
             TradeDefinition t = !r.trades().isEmpty() ? r.trades().get(0) : null;
@@ -694,44 +683,83 @@ public class ConvoyManager {
                 } else if (t.outputItem() != null) {
                     item = t.outputItem().clone();
                 } else {
-                    item = new ItemStack(Material.PAPER);
+                    item = layout.routeItem().clone();
                 }
             } else {
-                item = new ItemStack(Material.PAPER);
+                item = layout.routeItem().clone();
             }
-            var meta = item.getItemMeta();
-            if (meta != null) {
-                meta.setDisplayName("§e" + r.displayName());
-                List<String> lore = new ArrayList<>();
-                lore.add("§7" + r.description());
-                if (t != null) {
-                    if (t.inputItem() != null) {
-                        ItemStack need = t.inputItem();
-                        lore.add("§7Needs: " + need.getAmount() + "x " + need.getType().name());
-                    } else if (t.inputMoney() > 0) {
-                        lore.add("§7Needs: $" + t.inputMoney());
-                    }
+            if (layout.routeItemUseTradeTexture() && t != null) {
+                if (t.inputItem() != null) {
+                    item.setType(t.inputItem().getType());
+                } else if (t.outputItem() != null) {
+                    item.setType(t.outputItem().getType());
                 }
-                meta.setLore(lore);
-                item.setItemMeta(meta);
             }
-            int slot = ROUTE_SLOTS.get(idx - start);
+            applyPlaceholders(item, buildRoutePlaceholders(r, t, state.getPage() + 1));
+            int slot = layout.routeSlots().get(idx - start);
             inv.setItem(slot, item);
         }
 
         if (state.getPage() > 0) {
-            ItemStack prev = new ItemStack(Material.ARROW);
-            var pm = prev.getItemMeta();
-            if (pm != null) { pm.setDisplayName("§ePrev"); prev.setItemMeta(pm); }
-            inv.setItem(GUI_PREV_SLOT, prev);
+            ItemStack prev = layout.prevItem().clone();
+            applyPlaceholders(prev, Map.of("{page}", String.valueOf(state.getPage() + 1)));
+            inv.setItem(layout.prevSlot(), prev);
         }
-        if ((state.getPage() + 1) * GUI_PAGE_SIZE < state.getRoutes().size()) {
-            ItemStack next = new ItemStack(Material.ARROW);
-            var nm = next.getItemMeta();
-            if (nm != null) { nm.setDisplayName("§eNext"); next.setItemMeta(nm); }
-            inv.setItem(GUI_NEXT_SLOT, next);
+        if ((state.getPage() + 1) * pageSize < state.getRoutes().size()) {
+            ItemStack next = layout.nextItem().clone();
+            applyPlaceholders(next, Map.of("{page}", String.valueOf(state.getPage() + 2)));
+            inv.setItem(layout.nextSlot(), next);
         }
 
         p.openInventory(inv);
     }
+    private Map<String, String> buildRoutePlaceholders(RouteDefinition r, TradeDefinition t, int page) {
+        Map<String, String> ph = new HashMap<>();
+        ph.put("{route_id}", r.id());
+        ph.put("{route_name}", r.displayName());
+        ph.put("{route_description}", r.description());
+        ph.put("{page}", String.valueOf(page));
+
+        ph.put("{input_item_material}", "NONE");
+        ph.put("{input_item_amount}", "0");
+        ph.put("{output_item_material}", "NONE");
+        ph.put("{output_item_amount}", "0");
+        ph.put("{input_money}", "0");
+        ph.put("{output_money}", "0");
+
+        if (t != null) {
+            if (t.inputItem() != null) {
+                ph.put("{input_item_material}", t.inputItem().getType().name());
+                ph.put("{input_item_amount}", String.valueOf(t.inputItem().getAmount()));
+            }
+            if (t.outputItem() != null) {
+                ph.put("{output_item_material}", t.outputItem().getType().name());
+                ph.put("{output_item_amount}", String.valueOf(t.outputItem().getAmount()));
+            }
+            ph.put("{input_money}", String.valueOf(t.inputMoney()));
+            ph.put("{output_money}", String.valueOf(t.outputMoney()));
+        }
+        return ph;
+    }
+
+    private void applyPlaceholders(ItemStack item, Map<String, String> placeholders) {
+        var meta = item.getItemMeta();
+        if (meta == null) return;
+        if (meta.getDisplayName() != null) {
+            String name = meta.getDisplayName();
+            for (var entry : placeholders.entrySet()) name = name.replace(entry.getKey(), entry.getValue());
+            meta.setDisplayName(name);
+        }
+        if (meta.getLore() != null) {
+            List<String> lore = new ArrayList<>();
+            for (String line : meta.getLore()) {
+                String out = line;
+                for (var entry : placeholders.entrySet()) out = out.replace(entry.getKey(), entry.getValue());
+                lore.add(out);
+            }
+            meta.setLore(lore);
+        }
+        item.setItemMeta(meta);
+    }
+
 }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/GuiConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/GuiConfig.java
@@ -1,0 +1,138 @@
+package me.luisgamedev.bettertradeconvoys.service;
+
+import me.luisgamedev.bettertradeconvoys.BetterTradeConvoys;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+public class GuiConfig {
+    private final BetterTradeConvoys plugin;
+
+    private String defaultLayout = "default";
+    private final java.util.Map<String, GuiLayout> layouts = new java.util.HashMap<>();
+
+    public GuiConfig(BetterTradeConvoys plugin) {
+        this.plugin = plugin;
+    }
+
+    public void load() {
+        layouts.clear();
+        File f = new File(plugin.getDataFolder(), "gui.yml");
+        if (!f.exists()) {
+            plugin.saveResource("gui.yml", false);
+        }
+
+        YamlConfiguration cfg = YamlConfiguration.loadConfiguration(f);
+        defaultLayout = cfg.getString("default-layout", "default").toLowerCase(Locale.ROOT);
+
+        ConfigurationSection sec = cfg.getConfigurationSection("layouts");
+        if (sec == null) {
+            plugin.getLogger().warning("No 'layouts' section found in gui.yml");
+            return;
+        }
+
+        for (String key : sec.getKeys(false)) {
+            ConfigurationSection ls = sec.getConfigurationSection(key);
+            if (ls == null) continue;
+            String id = key.toLowerCase(Locale.ROOT);
+            String title = color(ls.getString("title", "Routes"));
+            int size = normalizeSize(ls.getInt("size", 54));
+
+            ItemStack border = parseGuiItem(ls.getConfigurationSection("border-item"), Material.GRAY_STAINED_GLASS_PANE, " ", Collections.emptyList());
+            ItemStack routeTemplate = parseGuiItem(ls.getConfigurationSection("route-item"), Material.PAPER, "&e{route_name}", Collections.singletonList("&7{route_description}"));
+            boolean useTradeTexture = ls.getBoolean("route-item-use-trade-texture", true);
+            ItemStack prev = parseGuiItem(ls.getConfigurationSection("prev-item"), Material.ARROW, "&ePrev", Collections.singletonList("&7Page {page}"));
+            ItemStack next = parseGuiItem(ls.getConfigurationSection("next-item"), Material.ARROW, "&eNext", Collections.singletonList("&7Page {page}"));
+
+            int prevSlot = clampSlot(ls.getInt("prev-slot", 37), size);
+            int nextSlot = clampSlot(ls.getInt("next-slot", 43), size);
+
+            List<Integer> routeSlots = ls.getIntegerList("route-slots");
+            if (routeSlots == null || routeSlots.isEmpty()) {
+                routeSlots = defaultRouteSlots(size, prevSlot, nextSlot);
+            } else {
+                List<Integer> filtered = new ArrayList<>();
+                for (Integer s : routeSlots) {
+                    if (s == null) continue;
+                    int slot = clampSlot(s, size);
+                    if (slot == prevSlot || slot == nextSlot || filtered.contains(slot)) continue;
+                    filtered.add(slot);
+                }
+                routeSlots = filtered;
+            }
+
+            layouts.put(id, new GuiLayout(id, title, size, border, routeTemplate, useTradeTexture, prev, next, prevSlot, nextSlot, routeSlots));
+        }
+
+        if (!layouts.containsKey(defaultLayout) && !layouts.isEmpty()) {
+            defaultLayout = layouts.keySet().iterator().next();
+        }
+    }
+
+    public GuiLayout getLayoutOrDefault(String id) {
+        if (layouts.isEmpty()) return null;
+        if (id != null && layouts.containsKey(id.toLowerCase(Locale.ROOT))) return layouts.get(id.toLowerCase(Locale.ROOT));
+        return layouts.get(defaultLayout);
+    }
+
+    private static String color(String s) { return ChatColor.translateAlternateColorCodes('&', s == null ? "" : s); }
+
+    private static int normalizeSize(int size) {
+        int s = Math.max(9, Math.min(54, size));
+        return (s / 9) * 9;
+    }
+
+    private static int clampSlot(int slot, int size) {
+        if (slot < 0) return 0;
+        if (slot >= size) return size - 1;
+        return slot;
+    }
+
+    private static List<Integer> defaultRouteSlots(int size, int prevSlot, int nextSlot) {
+        List<Integer> slots = new ArrayList<>();
+        int rows = size / 9;
+        for (int row = 1; row < rows - 1; row++) {
+            for (int col = 1; col <= 7; col++) {
+                int slot = row * 9 + col;
+                if (slot >= size || slot == prevSlot || slot == nextSlot) continue;
+                slots.add(slot);
+            }
+        }
+        return slots;
+    }
+
+    private ItemStack parseGuiItem(ConfigurationSection sec, Material fallbackMat, String fallbackName, List<String> fallbackLore) {
+        Material mat = fallbackMat;
+        String name = fallbackName;
+        List<String> lore = new ArrayList<>(fallbackLore);
+        if (sec != null) {
+            String materialName = sec.getString("material", fallbackMat.name());
+            try { mat = Material.valueOf(materialName.toUpperCase(Locale.ROOT)); } catch (Exception ignored) {}
+            name = sec.getString("name", fallbackName);
+            lore = sec.getStringList("lore");
+        }
+
+        ItemStack item = new ItemStack(mat);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(color(name));
+            List<String> translatedLore = new ArrayList<>();
+            for (String line : lore) translatedLore.add(color(line));
+            meta.setLore(translatedLore);
+            item.setItemMeta(meta);
+        }
+        return item;
+    }
+
+    public record GuiLayout(String id, String title, int size, ItemStack borderItem, ItemStack routeItem,
+                            boolean routeItemUseTradeTexture, ItemStack prevItem, ItemStack nextItem, int prevSlot, int nextSlot, List<Integer> routeSlots) {}
+}

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
@@ -121,6 +121,8 @@ public class RoutesConfig {
             int monthlyLimit = rs.getInt("monthly-limit", 0);
             int cooldown = rs.getInt("cooldown-seconds", 0);
 
+            String guiLayout = rs.getString("gui-layout", "default");
+
             // npc-ids
             Set<Integer> npcIds = new HashSet<>();
             for (Object o : rs.getList("npc-ids", Collections.emptyList())) {
@@ -146,6 +148,7 @@ public class RoutesConfig {
                     expireSeconds,
                     tradeDelaySeconds,
                     announceStart,
+                    guiLayout,
                     npcIds
             );
 

--- a/BetterTradeConvoys/src/main/resources/gui.yml
+++ b/BetterTradeConvoys/src/main/resources/gui.yml
@@ -1,0 +1,69 @@
+default-layout: default
+
+layouts:
+  default:
+    title: "&8Trade Convoy Routes"
+    size: 54
+    prev-slot: 37
+    next-slot: 43
+
+    # Optional, if omitted default slots will be generated in the inner area.
+    route-slots:
+      - 10
+      - 11
+      - 12
+      - 13
+      - 14
+      - 15
+      - 16
+      - 19
+      - 20
+      - 21
+      - 22
+      - 23
+      - 24
+      - 25
+      - 28
+      - 29
+      - 30
+      - 31
+      - 32
+      - 33
+      - 34
+      - 38
+      - 39
+      - 40
+      - 41
+      - 42
+
+    border-item:
+      material: GRAY_STAINED_GLASS_PANE
+      name: " "
+      lore: []
+
+    route-item:
+      material: PAPER
+      name: "&e{route_name}"
+      lore:
+        - "&7{route_description}"
+        - ""
+        - "&7Input Item: &f{input_item_amount}x {input_item_material}"
+        - "&7Input Money: &f${input_money}"
+        - "&7Output Item: &f{output_item_amount}x {output_item_material}"
+        - "&7Output Money: &f${output_money}"
+        - ""
+        - "&8Route ID: &7{route_id}"
+
+    prev-item:
+      material: ARROW
+      name: "&ePrev"
+      lore:
+        - "&7Back to previous page"
+        - "&8Page: {page}"
+
+    next-item:
+      material: ARROW
+      name: "&eNext"
+      lore:
+        - "&7Go to next page"
+        - "&8Page: {page}"

--- a/BetterTradeConvoys/src/main/resources/routes.yml
+++ b/BetterTradeConvoys/src/main/resources/routes.yml
@@ -7,6 +7,7 @@ routes:
     description: "Trade iron for diamonds"
     npc-ids: [0, 1, 2] # NPCs that should have the routes GUI when clicked
     waypoint-world: "world"
+    gui-layout: "default"
 
     # Movement
     speed: 1                    # Citizens speedModifier (1.0 = normal)
@@ -39,6 +40,7 @@ routes:
     description: "Trade gold for netherite"
     npc-ids: [0, 1, 2]
     waypoint-world: "world"
+    gui-layout: "default"
 
     speed: 1
     follow-radius: 10
@@ -67,6 +69,7 @@ routes:
     description: "Swap coal for emeralds"
     npc-ids: [0, 1, 2]
     waypoint-world: "world"
+    gui-layout: "default"
 
     speed: 1
     follow-radius: 10


### PR DESCRIPTION
### Motivation
- Erlaube flexible Anpassung der Inventar-GUIs (Größe, Titel, Items, Slots, Lores) ohne Code-Änderungen, damit Server-Admins eigene Layouts und Platzhalter nutzen können.
- Jede Route soll ein bestimmbares GUI-Layout wählen können, damit verschiedene NPCs unterschiedliche Menüs anzeigen können.

### Description
- Neue Konfiguration `src/main/resources/gui.yml` mit einem vollständigen `default`-Layout-Demo, das Titel, Inventargröße, `border`-Item, `route`-Item (Name + Lore), `prev`/`next`-Items, `route-slots` und Platzhalter-Beispiele enthält. 
- Neuer Loader/Service `src/main/java/me/luisgamedev/bettertradeconvoys/service/GuiConfig.java` zum Einlesen, Validieren und Bereitstellen von GUI-Layouts.
- Erweiterung des Routendatenmodells um das Feld `gui-layout` und Anpassung des Loaders in `src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java` zum Parsen von `gui-layout`.
- Injection von `GuiConfig` beim Plugin-Start (`BetterTradeConvoys`) und Anpassung von `ConvoyManager` + `RoutesGuiListener` zur Laufzeitnutzung der konfigurierten Layouts (Titel, Slots, Seitengröße, Prev/Next-Slots) sowie Implementierung von Platzhalter-Substitution für `{route_name}`, `{route_description}`, `{route_id}`, `{input_item_*}`, `{output_item_*}`, `{input_money}`, `{output_money}` und `{page}`.

### Testing
- Projekt-Build mit `./gradlew build -x test` wurde lokal ausgeführt und beendet sich erfolgreich (`BUILD SUCCESSFUL`).
- Die neuen Konfigurationsdateien werden per `saveResource("gui.yml")` bereitgestellt, und der `GuiConfig.load()`-Pfad wurde beim Plugin-Startup integriert und geladen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a087d82a288832bbd5b8b8d96de853a)