### PR TITLE
Add PlaceholderAPI compatibility and convoy placeholders

### DIFF
--- a/BetterTradeConvoys/build.gradle
+++ b/BetterTradeConvoys/build.gradle
@@ -21,6 +21,7 @@ repositories {
         name = 'citizens-repo'
         url = 'https://maven.citizensnpcs.co/repo'
     }
+    maven { url = 'https://repo.extendedclip.com/content/repositories/placeholderapi/' }
     flatDir { dirs 'libs' }
 }
 
@@ -31,6 +32,7 @@ dependencies {
     compileOnly('net.citizensnpcs:citizens-main:2.0.35-SNAPSHOT') {
         exclude group: '*', module: '*'
     }
+    compileOnly 'me.clip:placeholderapi:2.11.6'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/BetterTradeConvoys.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/BetterTradeConvoys.java
@@ -8,6 +8,7 @@ import me.luisgamedev.bettertradeconvoys.service.ConvoyManager;
 import me.luisgamedev.bettertradeconvoys.service.PlayerProgressStore;
 import me.luisgamedev.bettertradeconvoys.service.RoutesConfig;
 import me.luisgamedev.bettertradeconvoys.service.GuiConfig;
+import me.luisgamedev.bettertradeconvoys.placeholders.BetterTradeConvoysExpansion;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import net.milkbowl.vault.economy.Economy;
@@ -42,6 +43,10 @@ public final class BetterTradeConvoys extends JavaPlugin {
         setupEconomy();
 
         convoyManager = new ConvoyManager(this, routesConfig, progressStore, guiConfig, language);
+        if (getServer().getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            new BetterTradeConvoysExpansion(this).register();
+            getLogger().info("Hooked into PlaceholderAPI.");
+        }
         convoyManager.initCitizensCheck();
 
         Bukkit.getPluginManager().registerEvents(new CitizensListeners(convoyManager, language, routesConfig), this);

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/language/LanguageManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/language/LanguageManager.java
@@ -1,6 +1,8 @@
 package me.luisgamedev.bettertradeconvoys.language;
 
+import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;
 
@@ -29,30 +31,55 @@ public class LanguageManager {
     }
 
     public String get(String path) {
+        return get(null, path);
+    }
+
+    public String get(OfflinePlayer player, String path) {
         String v = cfg.getString(path);
         if (v == null) return prefix + ChatColor.RED + "Missing lang key: " + path;
-        return prefix + colorize(v);
+        return prefix + applyPlaceholders(player, colorize(v));
     }
 
     public String getRaw(String path) {
+        return getRaw(null, path);
+    }
+
+    public String getRaw(OfflinePlayer player, String path) {
         String v = cfg.getString(path);
         if (v == null) return "Missing lang key: " + path;
-        return colorize(v);
+        return applyPlaceholders(player, colorize(v));
     }
 
     public String format(String path, Map<String, Object> placeholders) {
+        return format(null, path, placeholders);
+    }
+
+    public String format(OfflinePlayer player, String path, Map<String, Object> placeholders) {
         String base = cfg.getString(path);
         if (base == null) base = "Missing lang key: " + path;
         String colored = colorize(base);
         String withVars = replacePlaceholders(colored, placeholders);
-        return prefix + withVars;
+        return prefix + applyPlaceholders(player, withVars);
     }
 
     public String formatRaw(String path, Map<String, Object> placeholders) {
+        return formatRaw(null, path, placeholders);
+    }
+
+    public String formatRaw(OfflinePlayer player, String path, Map<String, Object> placeholders) {
         String base = cfg.getString(path);
         if (base == null) base = "Missing lang key: " + path;
         String colored = colorize(base);
-        return replacePlaceholders(colored, placeholders);
+        return applyPlaceholders(player, replacePlaceholders(colored, placeholders));
+    }
+
+    private String applyPlaceholders(OfflinePlayer player, String s) {
+        if (plugin.getServer().getPluginManager().getPlugin("PlaceholderAPI") == null) return s;
+        try {
+            return PlaceholderAPI.setPlaceholders(player, s);
+        } catch (Throwable ignored) {
+            return s;
+        }
     }
 
     private String colorize(String s) {

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/placeholders/BetterTradeConvoysExpansion.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/placeholders/BetterTradeConvoysExpansion.java
@@ -1,0 +1,64 @@
+package me.luisgamedev.bettertradeconvoys.placeholders;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import me.luisgamedev.bettertradeconvoys.BetterTradeConvoys;
+import me.luisgamedev.bettertradeconvoys.model.ConvoyInstance;
+import me.luisgamedev.bettertradeconvoys.model.RouteDefinition;
+import org.bukkit.OfflinePlayer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public class BetterTradeConvoysExpansion extends PlaceholderExpansion {
+
+    private final BetterTradeConvoys plugin;
+
+    public BetterTradeConvoysExpansion(BetterTradeConvoys plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override public @NotNull String getIdentifier() { return "bettertradeconvoys"; }
+    @Override public @NotNull String getAuthor() { return "Luis-GameDev"; }
+    @Override public @NotNull String getVersion() { return plugin.getDescription().getVersion(); }
+    @Override public boolean persist() { return true; }
+
+    @Override
+    public String onRequest(OfflinePlayer player, @NotNull String params) {
+        if (player == null) return "";
+        String[] parts = params.split("_", 2);
+        if (parts.length < 2) return "";
+        String key = parts[0];
+        String routeId = parts[1];
+
+        RouteDefinition route = plugin.routes().getRoute(routeId);
+        if (route == null) return "0";
+        UUID uuid = player.getUniqueId();
+
+        long now = System.currentTimeMillis();
+        long last = plugin.progress().getLastStartMillis(uuid, routeId);
+        long cooldownLeft = Math.max(0L, route.cooldownSeconds() - ((now - last) / 1000));
+
+        int dailyUsed = plugin.progress().getStartsToday(uuid, routeId);
+        int weeklyUsed = plugin.progress().getStartsThisWeek(uuid, routeId);
+        int monthlyUsed = plugin.progress().getStartsThisMonth(uuid, routeId);
+
+        return switch (key) {
+            case "cooldown" -> String.valueOf(cooldownLeft);
+            case "dailyused" -> String.valueOf(dailyUsed);
+            case "weeklyused" -> String.valueOf(weeklyUsed);
+            case "monthlyused" -> String.valueOf(monthlyUsed);
+            case "dailyleft" -> left(route.dailyLimit(), dailyUsed);
+            case "weeklyleft" -> left(route.weeklyLimit(), weeklyUsed);
+            case "monthlyleft" -> left(route.monthlyLimit(), monthlyUsed);
+            case "dailylimit" -> String.valueOf(route.dailyLimit());
+            case "weeklylimit" -> String.valueOf(route.weeklyLimit());
+            case "monthlylimit" -> String.valueOf(route.monthlyLimit());
+            default -> "";
+        };
+    }
+
+    private String left(int limit, int used) {
+        if (limit < 0) return "-1";
+        return String.valueOf(Math.max(0, limit - used));
+    }
+}

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -104,7 +104,7 @@ public class ConvoyManager {
         long now = System.currentTimeMillis();
         if (rd.cooldownSeconds() > 0 && (now - last) / 1000 < rd.cooldownSeconds()) {
             long remain = rd.cooldownSeconds() - ((now - last) / 1000);
-            return lang.format("errors.cooldown_active", lang.p("route", rd.displayName(), "seconds", remain));
+            return lang.format(owner, "errors.cooldown_active", lang.p("route", rd.displayName(), "seconds", remain));
         }
 
         if (rd.steps() == null || rd.steps().isEmpty()) {
@@ -202,7 +202,7 @@ public class ConvoyManager {
         progress.incStartsThisMonth(owner.getUniqueId(), routeId);
         progress.setLastStartMillis(owner.getUniqueId(), routeId, now);
 
-        return lang.format("info.started", lang.p("name", rd.displayName()));
+        return lang.format(owner, "info.started", lang.p("name", rd.displayName()));
     }
 
     private int findNextIndex(RouteDefinition rd, int from) {

--- a/BetterTradeConvoys/src/main/resources/plugin.yml
+++ b/BetterTradeConvoys/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: me.luisgamedev.bettertradeconvoys.BetterTradeConvoys
 version: 1.1
 api-version: '1.20'
 website: 'https://github.com/Luis-GameDev'
-softdepend: [ Citizens, Vault ]
+softdepend: [ Citizens, Vault, PlaceholderAPI ]
 
 permissions:
   bettertradeconvoys.use:


### PR DESCRIPTION
### Motivation
- Allow language/config strings to include `%...%` PlaceholderAPI tokens and resolve them with player context. 
- Expose runtime convoy data (cooldown, used/left limits) as placeholders so server owners can reference route state in messages and GUIs.

### Description
- Added PlaceholderAPI compile-time dependency and repository entry in `build.gradle` so the project compiles against PAPI APIs. 
- Declared `PlaceholderAPI` as a soft dependency in `plugin.yml` and register a `BetterTradeConvoysExpansion` on startup when PAPI is present. 
- Extended `LanguageManager` with player-aware overloads for `get`, `getRaw`, `format` and `formatRaw` and added `applyPlaceholders(...)` to run `PlaceholderAPI.setPlaceholders(...)` on config text. 
- Added `BetterTradeConvoysExpansion` implementing `%bettertradeconvoys_<key>_<routeId>%` placeholders (keys: `cooldown`, `dailyused`, `weeklyused`, `monthlyused`, `dailyleft`, `weeklyleft`, `monthlyleft`, `dailylimit`, `weeklylimit`, `monthlylimit`). 
- Updated `ConvoyManager` to pass the owner player into language formatting for cooldown/start messages so placeholders resolve for the correct player. 

### Testing
- Ran `bash ./gradlew build -x test` in the `BetterTradeConvoys` subproject and the build completed successfully. 
- Noted earlier `./gradlew` execution failed due to executable permission, which does not affect the artifact build when running via `bash ./gradlew`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0882eee8d4832bb82bbdd221a32eb1)