### PR TITLE
Support `item-model` and `custom-model-data` for GUI and per-route items

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/RouteDefinition.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/RouteDefinition.java
@@ -20,5 +20,7 @@ public record RouteDefinition(
         int tradeDelaySeconds,
         boolean announceStart,
         String guiLayout,
+        Integer guiCustomModelData,
+        String guiItemModel,
         Set<Integer> npcIds
 ) { }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -11,10 +11,12 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import java.lang.reflect.Method;
 import java.util.*;
 
 public class ConvoyManager {
@@ -798,6 +800,7 @@ public class ConvoyManager {
                     item.setType(t.outputItem().getType());
                 }
             }
+            applyRouteGuiModel(item, r);
             applyPlaceholders(item, buildRoutePlaceholders(r, t, state.getPage() + 1));
             int slot = layout.routeSlots().get(idx - start);
             inv.setItem(slot, item);
@@ -861,6 +864,29 @@ public class ConvoyManager {
                 lore.add(out);
             }
             meta.setLore(lore);
+        }
+        item.setItemMeta(meta);
+    }
+
+    private void applyRouteGuiModel(ItemStack item, RouteDefinition route) {
+        var meta = item.getItemMeta();
+        if (meta == null) return;
+        if (route.guiCustomModelData() != null) meta.setCustomModelData(route.guiCustomModelData());
+
+        if (route.guiItemModel() != null && !route.guiItemModel().isBlank()) {
+            NamespacedKey itemModel = NamespacedKey.fromString(route.guiItemModel().trim());
+            if (itemModel == null) {
+                plugin.getLogger().warning("Invalid gui-item-model key '" + route.guiItemModel() + "' in route '" + route.id() + "'");
+            } else {
+                try {
+                    Method setItemModel = meta.getClass().getMethod("setItemModel", NamespacedKey.class);
+                    setItemModel.invoke(meta, itemModel);
+                } catch (NoSuchMethodException ignored) {
+                    // Not available on this server version.
+                } catch (Exception e) {
+                    plugin.getLogger().warning("Could not apply gui-item-model '" + route.guiItemModel() + "' for route '" + route.id() + "': " + e.getMessage());
+                }
+            }
         }
         item.setItemMeta(meta);
     }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/GuiConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/GuiConfig.java
@@ -3,12 +3,14 @@ package me.luisgamedev.bettertradeconvoys.service;
 import me.luisgamedev.bettertradeconvoys.BetterTradeConvoys;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.io.File;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -128,9 +130,37 @@ public class GuiConfig {
             List<String> translatedLore = new ArrayList<>();
             for (String line : lore) translatedLore.add(color(line));
             meta.setLore(translatedLore);
+            applyCustomModelData(sec, meta);
+            applyItemModel(sec, meta);
             item.setItemMeta(meta);
         }
         return item;
+    }
+
+    private void applyCustomModelData(ConfigurationSection sec, ItemMeta meta) {
+        if (sec == null || !sec.contains("custom-model-data")) return;
+        int customModelData = sec.getInt("custom-model-data");
+        meta.setCustomModelData(customModelData);
+    }
+
+    private void applyItemModel(ConfigurationSection sec, ItemMeta meta) {
+        if (sec == null || !sec.contains("item-model")) return;
+        String rawItemModel = sec.getString("item-model");
+        if (rawItemModel == null || rawItemModel.isBlank()) return;
+        NamespacedKey itemModel = NamespacedKey.fromString(rawItemModel.trim());
+        if (itemModel == null) {
+            plugin.getLogger().warning("Invalid item-model key in gui.yml: " + rawItemModel);
+            return;
+        }
+
+        try {
+            Method setItemModel = meta.getClass().getMethod("setItemModel", NamespacedKey.class);
+            setItemModel.invoke(meta, itemModel);
+        } catch (NoSuchMethodException ignored) {
+            // Not available on this server version.
+        } catch (Exception e) {
+            plugin.getLogger().warning("Could not apply item-model '" + rawItemModel + "' from gui.yml: " + e.getMessage());
+        }
     }
 
     public record GuiLayout(String id, String title, int size, ItemStack borderItem, ItemStack routeItem,

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
@@ -122,6 +122,8 @@ public class RoutesConfig {
             int cooldown = rs.getInt("cooldown-seconds", 0);
 
             String guiLayout = rs.getString("gui-layout", "default");
+            Integer guiCustomModelData = rs.contains("gui-custom-model-data") ? rs.getInt("gui-custom-model-data") : null;
+            String guiItemModel = rs.getString("gui-item-model");
 
             // npc-ids
             Set<Integer> npcIds = new HashSet<>();
@@ -149,6 +151,8 @@ public class RoutesConfig {
                     tradeDelaySeconds,
                     announceStart,
                     guiLayout,
+                    guiCustomModelData,
+                    guiItemModel,
                     npcIds
             );
 

--- a/BetterTradeConvoys/src/main/resources/gui.yml
+++ b/BetterTradeConvoys/src/main/resources/gui.yml
@@ -39,11 +39,17 @@ layouts:
     border-item:
       material: GRAY_STAINED_GLASS_PANE
       name: " "
+      item-model: "minecraft:gray_stained_glass_pane"
+      custom-model-data: 2001
       lore: []
 
     route-item:
       material: PAPER
       name: "&e{route_name}"
+      # Optional: item-model uses a namespaced key (1.21.4+ API support).
+      item-model: "minecraft:paper"
+      # Optional: custom-model-data is supported on modern resource packs.
+      custom-model-data: 1001
       lore:
         - "&7{route_description}"
         - ""
@@ -57,6 +63,8 @@ layouts:
     prev-item:
       material: ARROW
       name: "&ePrev"
+      item-model: "minecraft:arrow"
+      custom-model-data: 2002
       lore:
         - "&7Back to previous page"
         - "&8Page: {page}"
@@ -64,6 +72,8 @@ layouts:
     next-item:
       material: ARROW
       name: "&eNext"
+      item-model: "minecraft:arrow"
+      custom-model-data: 2003
       lore:
         - "&7Go to next page"
         - "&8Page: {page}"

--- a/BetterTradeConvoys/src/main/resources/routes.yml
+++ b/BetterTradeConvoys/src/main/resources/routes.yml
@@ -8,6 +8,8 @@ routes:
     npc-ids: [0, 1, 2] # NPCs that should have the routes GUI when clicked
     waypoint-world: "world"
     gui-layout: "default"
+    gui-item-model: "minecraft:paper"
+    gui-custom-model-data: 1101
 
     # Movement
     speed: 1                    # Citizens speedModifier (1.0 = normal)
@@ -41,6 +43,8 @@ routes:
     npc-ids: [0, 1, 2]
     waypoint-world: "world"
     gui-layout: "default"
+    gui-item-model: "minecraft:paper"
+    gui-custom-model-data: 1102
 
     speed: 1
     follow-radius: 10
@@ -70,6 +74,8 @@ routes:
     npc-ids: [0, 1, 2]
     waypoint-world: "world"
     gui-layout: "default"
+    gui-item-model: "minecraft:paper"
+    gui-custom-model-data: 1103
 
     speed: 1
     follow-radius: 10


### PR DESCRIPTION
### Motivation
- Add support for modern resource-pack-driven item models and custom model data in GUI elements and per-route overrides using the namespaced key API.
- Maintain backwards compatibility with older server versions by applying the `setItemModel` API reflectively and falling back gracefully when not available.

### Description
- Added `guiCustomModelData` and `guiItemModel` fields to the `RouteDefinition` record to allow per-route GUI model overrides via `gui-item-model` and `gui-custom-model-data` in `routes.yml`.
- Read `gui-item-model` and `gui-custom-model-data` in `RoutesConfig` and pass them into `RouteDefinition` when loading routes.
- Updated `GuiConfig` to parse `item-model` and `custom-model-data` in `gui.yml` via new helper methods `applyItemModel` and `applyCustomModelData`, and apply them to parsed `ItemMeta` using reflection on `setItemModel` with `NamespacedKey.fromString`.
- Added `applyRouteGuiModel` in `ConvoyManager` to apply per-route `gui-item-model` and `gui-custom-model-data` to route `ItemStack`s, including logging for invalid keys and exceptions, and fallback when the API method doesn't exist.
- Updated resource examples `gui.yml` and `routes.yml` to demonstrate `item-model` and `custom-model-data` usage.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08848794c4832b864488f60070f5a0)