### PR TITLE
Make route GUI item material/model configurable per-route (move from gui.yml to routes.yml)

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/RouteDefinition.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/RouteDefinition.java
@@ -2,6 +2,7 @@ package me.luisgamedev.bettertradeconvoys.model;
 
 import java.util.List;
 import java.util.Set;
+import org.bukkit.Material;
 
 public record RouteDefinition(
         String id,
@@ -20,6 +21,7 @@ public record RouteDefinition(
         int tradeDelaySeconds,
         boolean announceStart,
         String guiLayout,
+        Material guiItemMaterial,
         Integer guiCustomModelData,
         String guiItemModel,
         Set<Integer> npcIds

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -781,25 +781,7 @@ public class ConvoyManager {
         for (int idx = start; idx < end; idx++) {
             RouteDefinition r = state.getRoutes().get(idx);
             TradeDefinition t = !r.trades().isEmpty() ? r.trades().get(0) : null;
-            ItemStack item;
-            if (t != null) {
-                if (t.inputItem() != null) {
-                    item = t.inputItem().clone();
-                } else if (t.outputItem() != null) {
-                    item = t.outputItem().clone();
-                } else {
-                    item = layout.routeItem().clone();
-                }
-            } else {
-                item = layout.routeItem().clone();
-            }
-            if (layout.routeItemUseTradeTexture() && t != null) {
-                if (t.inputItem() != null) {
-                    item.setType(t.inputItem().getType());
-                } else if (t.outputItem() != null) {
-                    item.setType(t.outputItem().getType());
-                }
-            }
+            ItemStack item = layout.routeItem().clone();
             applyRouteGuiModel(item, r);
             applyPlaceholders(item, buildRoutePlaceholders(r, t, state.getPage() + 1));
             int slot = layout.routeSlots().get(idx - start);
@@ -871,6 +853,7 @@ public class ConvoyManager {
     private void applyRouteGuiModel(ItemStack item, RouteDefinition route) {
         var meta = item.getItemMeta();
         if (meta == null) return;
+        item.setType(route.guiItemMaterial() != null ? route.guiItemMaterial() : Material.PAPER);
         if (route.guiCustomModelData() != null) meta.setCustomModelData(route.guiCustomModelData());
 
         if (route.guiItemModel() != null && !route.guiItemModel().isBlank()) {

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/GuiConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/GuiConfig.java
@@ -51,7 +51,6 @@ public class GuiConfig {
 
             ItemStack border = parseGuiItem(ls.getConfigurationSection("border-item"), Material.GRAY_STAINED_GLASS_PANE, " ", Collections.emptyList());
             ItemStack routeTemplate = parseGuiItem(ls.getConfigurationSection("route-item"), Material.PAPER, "&e{route_name}", Collections.singletonList("&7{route_description}"));
-            boolean useTradeTexture = ls.getBoolean("route-item-use-trade-texture", true);
             ItemStack prev = parseGuiItem(ls.getConfigurationSection("prev-item"), Material.ARROW, "&ePrev", Collections.singletonList("&7Page {page}"));
             ItemStack next = parseGuiItem(ls.getConfigurationSection("next-item"), Material.ARROW, "&eNext", Collections.singletonList("&7Page {page}"));
 
@@ -72,7 +71,7 @@ public class GuiConfig {
                 routeSlots = filtered;
             }
 
-            layouts.put(id, new GuiLayout(id, title, size, border, routeTemplate, useTradeTexture, prev, next, prevSlot, nextSlot, routeSlots));
+            layouts.put(id, new GuiLayout(id, title, size, border, routeTemplate, prev, next, prevSlot, nextSlot, routeSlots));
         }
 
         if (!layouts.containsKey(defaultLayout) && !layouts.isEmpty()) {
@@ -164,5 +163,5 @@ public class GuiConfig {
     }
 
     public record GuiLayout(String id, String title, int size, ItemStack borderItem, ItemStack routeItem,
-                            boolean routeItemUseTradeTexture, ItemStack prevItem, ItemStack nextItem, int prevSlot, int nextSlot, List<Integer> routeSlots) {}
+                            ItemStack prevItem, ItemStack nextItem, int prevSlot, int nextSlot, List<Integer> routeSlots) {}
 }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
@@ -122,6 +122,13 @@ public class RoutesConfig {
             int cooldown = rs.getInt("cooldown-seconds", 0);
 
             String guiLayout = rs.getString("gui-layout", "default");
+            Material guiItemMaterial = Material.PAPER;
+            String guiMaterialName = rs.getString("gui-item-material", "PAPER");
+            try {
+                guiItemMaterial = Material.valueOf(guiMaterialName.toUpperCase(Locale.ROOT));
+            } catch (Exception ex) {
+                plugin.getLogger().warning("Invalid gui-item-material '" + guiMaterialName + "' in route '" + id + "'. Falling back to PAPER.");
+            }
             Integer guiCustomModelData = rs.contains("gui-custom-model-data") ? rs.getInt("gui-custom-model-data") : null;
             String guiItemModel = rs.getString("gui-item-model");
 
@@ -151,6 +158,7 @@ public class RoutesConfig {
                     tradeDelaySeconds,
                     announceStart,
                     guiLayout,
+                    guiItemMaterial,
                     guiCustomModelData,
                     guiItemModel,
                     npcIds

--- a/BetterTradeConvoys/src/main/resources/gui.yml
+++ b/BetterTradeConvoys/src/main/resources/gui.yml
@@ -44,12 +44,7 @@ layouts:
       lore: []
 
     route-item:
-      material: PAPER
       name: "&e{route_name}"
-      # Optional: item-model uses a namespaced key (1.21.4+ API support).
-      item-model: "minecraft:paper"
-      # Optional: custom-model-data is supported on modern resource packs.
-      custom-model-data: 1001
       lore:
         - "&7{route_description}"
         - ""

--- a/BetterTradeConvoys/src/main/resources/routes.yml
+++ b/BetterTradeConvoys/src/main/resources/routes.yml
@@ -8,6 +8,7 @@ routes:
     npc-ids: [0, 1, 2] # NPCs that should have the routes GUI when clicked
     waypoint-world: "world"
     gui-layout: "default"
+    gui-item-material: PAPER
     gui-item-model: "minecraft:paper"
     gui-custom-model-data: 1101
 
@@ -43,6 +44,7 @@ routes:
     npc-ids: [0, 1, 2]
     waypoint-world: "world"
     gui-layout: "default"
+    gui-item-material: PAPER
     gui-item-model: "minecraft:paper"
     gui-custom-model-data: 1102
 
@@ -74,6 +76,7 @@ routes:
     npc-ids: [0, 1, 2]
     waypoint-world: "world"
     gui-layout: "default"
+    gui-item-material: PAPER
     gui-item-model: "minecraft:paper"
     gui-custom-model-data: 1103
 


### PR DESCRIPTION
### Motivation
- Route GUI item visuals (material, item-model, custom-model-data) should be specified per-route instead of globally in `gui.yml` so each route can control its own appearance.
- Everything except the generic GUI layout/template should remain in `gui.yml`, while route-specific visual overrides belong in `routes.yml` for clearer customization.

### Description
- Added a `guiItemMaterial` `Material` field to `RouteDefinition` so each route carries its own material. (`src/main/java/.../model/RouteDefinition.java`).
- Updated `RoutesConfig.load()` to parse a new `gui-item-material` property (validated with a PAPER fallback) and pass it into the `RouteDefinition`. (`src/main/java/.../service/RoutesConfig.java`).
- Changed GUI rendering in `ConvoyManager.renderRoutesGui()` to always clone the layout `route-item` template and then apply per-route `gui-item-material`, `gui-item-model`, and `gui-custom-model-data` via `applyRouteGuiModel()`, removing the previous trade-derived texture logic. (`src/main/java/.../service/ConvoyManager.java`).
- Removed `route-item` material/item-model/custom-model-data from the example `gui.yml` template and added `gui-item-material` defaults to `routes.yml` examples. (`src/main/resources/gui.yml`, `src/main/resources/routes.yml`).

### Testing
- Initial build with `./gradlew build -x test` failed due to `gradlew` not being executable. (failure observed).
- Made `gradlew` executable with `chmod +x gradlew` and ran `./gradlew build -x test`, which completed successfully (BUILD SUCCESSFUL).
- No automated unit tests were executed (build invoked with `-x test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0890c2e724832bbd5779aeb7fa0b11)