### PR TITLE
Rework routes GUI layout mapping and route item configuration

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/listeners/RoutesGuiListener.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/listeners/RoutesGuiListener.java
@@ -33,7 +33,7 @@ public class RoutesGuiListener implements Listener {
         event.setCancelled(true);
 
         int slot = event.getRawSlot();
-        if (slot == state.getLayout().prevSlot()) {
+        if (state.getLayout().prevSlots().contains(slot)) {
             if (state.getPage() > 0) {
                 state.setPage(state.getPage() - 1);
                 manager.renderRoutesGui(p, state);
@@ -41,7 +41,7 @@ public class RoutesGuiListener implements Listener {
             return;
         }
         int pageSize = state.getLayout().routeSlots().size();
-        if (slot == state.getLayout().nextSlot()) {
+        if (state.getLayout().nextSlots().contains(slot)) {
             if ((state.getPage() + 1) * pageSize < state.getRoutes().size()) {
                 state.setPage(state.getPage() + 1);
                 manager.renderRoutesGui(p, state);
@@ -90,4 +90,3 @@ public class RoutesGuiListener implements Listener {
         manager.closeRoutesGui(event.getPlayer().getUniqueId());
     }
 }
-

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/RouteDefinition.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/RouteDefinition.java
@@ -2,6 +2,7 @@ package me.luisgamedev.bettertradeconvoys.model;
 
 import java.util.List;
 import java.util.Set;
+import java.util.Collections;
 import org.bukkit.Material;
 
 public record RouteDefinition(
@@ -24,5 +25,11 @@ public record RouteDefinition(
         Material guiItemMaterial,
         Integer guiCustomModelData,
         String guiItemModel,
+        String guiItemName,
+        List<String> guiItemLore,
         Set<Integer> npcIds
-) { }
+) {
+    public List<String> guiItemLore() {
+        return guiItemLore == null ? Collections.emptyList() : guiItemLore;
+    }
+}

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -767,11 +767,15 @@ public class ConvoyManager {
 
         ItemStack glass = layout.borderItem().clone();
 
-        for (int i = 0; i < inv.getSize(); i++) {
-            int row = i / 9;
-            int col = i % 9;
-            if (row == 0 || row == (inv.getSize() / 9) - 1 || col == 0 || col == 8) {
-                inv.setItem(i, glass);
+        if (!layout.borderSlots().isEmpty()) {
+            for (int slot : layout.borderSlots()) {
+                if (slot >= 0 && slot < inv.getSize()) inv.setItem(slot, glass);
+            }
+        } else {
+            for (int i = 0; i < inv.getSize(); i++) {
+                int row = i / 9;
+                int col = i % 9;
+                if (row == 0 || row == (inv.getSize() / 9) - 1 || col == 0 || col == 8) inv.setItem(i, glass);
             }
         }
 
@@ -781,7 +785,7 @@ public class ConvoyManager {
         for (int idx = start; idx < end; idx++) {
             RouteDefinition r = state.getRoutes().get(idx);
             TradeDefinition t = !r.trades().isEmpty() ? r.trades().get(0) : null;
-            ItemStack item = layout.routeItem().clone();
+            ItemStack item = buildRouteGuiItem(r);
             applyRouteGuiModel(item, r);
             applyPlaceholders(item, buildRoutePlaceholders(r, t, state.getPage() + 1));
             int slot = layout.routeSlots().get(idx - start);
@@ -791,12 +795,12 @@ public class ConvoyManager {
         if (state.getPage() > 0) {
             ItemStack prev = layout.prevItem().clone();
             applyPlaceholders(prev, Map.of("{page}", String.valueOf(state.getPage() + 1)));
-            inv.setItem(layout.prevSlot(), prev);
+            for (int slot : layout.prevSlots()) if (slot >= 0 && slot < inv.getSize()) inv.setItem(slot, prev);
         }
         if ((state.getPage() + 1) * pageSize < state.getRoutes().size()) {
             ItemStack next = layout.nextItem().clone();
             applyPlaceholders(next, Map.of("{page}", String.valueOf(state.getPage() + 2)));
-            inv.setItem(layout.nextSlot(), next);
+            for (int slot : layout.nextSlots()) if (slot >= 0 && slot < inv.getSize()) inv.setItem(slot, next);
         }
 
         p.openInventory(inv);
@@ -872,6 +876,18 @@ public class ConvoyManager {
             }
         }
         item.setItemMeta(meta);
+    }
+
+    private ItemStack buildRouteGuiItem(RouteDefinition route) {
+        ItemStack item = new ItemStack(route.guiItemMaterial() != null ? route.guiItemMaterial() : Material.PAPER);
+        var meta = item.getItemMeta();
+        if (meta == null) return item;
+        meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', route.guiItemName()));
+        List<String> lore = new ArrayList<>();
+        for (String line : route.guiItemLore()) lore.add(ChatColor.translateAlternateColorCodes('&', line));
+        meta.setLore(lore);
+        item.setItemMeta(meta);
+        return item;
     }
 
 }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/GuiConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/GuiConfig.java
@@ -50,28 +50,38 @@ public class GuiConfig {
             int size = normalizeSize(ls.getInt("size", 54));
 
             ItemStack border = parseGuiItem(ls.getConfigurationSection("border-item"), Material.GRAY_STAINED_GLASS_PANE, " ", Collections.emptyList());
-            ItemStack routeTemplate = parseGuiItem(ls.getConfigurationSection("route-item"), Material.PAPER, "&e{route_name}", Collections.singletonList("&7{route_description}"));
             ItemStack prev = parseGuiItem(ls.getConfigurationSection("prev-item"), Material.ARROW, "&ePrev", Collections.singletonList("&7Page {page}"));
             ItemStack next = parseGuiItem(ls.getConfigurationSection("next-item"), Material.ARROW, "&eNext", Collections.singletonList("&7Page {page}"));
-
-            int prevSlot = clampSlot(ls.getInt("prev-slot", 37), size);
-            int nextSlot = clampSlot(ls.getInt("next-slot", 43), size);
-
-            List<Integer> routeSlots = ls.getIntegerList("route-slots");
-            if (routeSlots == null || routeSlots.isEmpty()) {
-                routeSlots = defaultRouteSlots(size, prevSlot, nextSlot);
-            } else {
-                List<Integer> filtered = new ArrayList<>();
-                for (Integer s : routeSlots) {
-                    if (s == null) continue;
-                    int slot = clampSlot(s, size);
-                    if (slot == prevSlot || slot == nextSlot || filtered.contains(slot)) continue;
-                    filtered.add(slot);
+            List<String> pattern = ls.getStringList("layout-pattern");
+            List<Integer> borderSlots = new ArrayList<>();
+            List<Integer> routeSlots = new ArrayList<>();
+            List<Integer> prevSlots = new ArrayList<>();
+            List<Integer> nextSlots = new ArrayList<>();
+            if (pattern != null && !pattern.isEmpty()) {
+                size = normalizeSize(pattern.size() * 9);
+                ConfigurationSection slotTypes = ls.getConfigurationSection("slot-types");
+                for (int row = 0; row < pattern.size(); row++) {
+                    String line = pattern.get(row);
+                    for (int col = 0; col < Math.min(9, line.length()); col++) {
+                        char patternKey = line.charAt(col);
+                        int slot = row * 9 + col;
+                        String type = slotTypes != null ? slotTypes.getString(String.valueOf(patternKey), "") : "";
+                        if ("BORDER".equalsIgnoreCase(type) || patternKey == '1') borderSlots.add(slot);
+                        else if ("ROUTE".equalsIgnoreCase(type) || patternKey == '0') routeSlots.add(slot);
+                        else if ("PREV".equalsIgnoreCase(type) || patternKey == '2') prevSlots.add(slot);
+                        else if ("NEXT".equalsIgnoreCase(type) || patternKey == '3') nextSlots.add(slot);
+                    }
                 }
-                routeSlots = filtered;
+            } else {
+                int prevSlot = clampSlot(ls.getInt("prev-slot", 37), size);
+                int nextSlot = clampSlot(ls.getInt("next-slot", 43), size);
+                prevSlots.add(prevSlot);
+                nextSlots.add(nextSlot);
+                routeSlots = ls.getIntegerList("route-slots");
+                if (routeSlots == null || routeSlots.isEmpty()) routeSlots = defaultRouteSlots(size, prevSlot, nextSlot);
             }
 
-            layouts.put(id, new GuiLayout(id, title, size, border, routeTemplate, prev, next, prevSlot, nextSlot, routeSlots));
+            layouts.put(id, new GuiLayout(id, title, size, border, prev, next, routeSlots, borderSlots, prevSlots, nextSlots));
         }
 
         if (!layouts.containsKey(defaultLayout) && !layouts.isEmpty()) {
@@ -162,6 +172,7 @@ public class GuiConfig {
         }
     }
 
-    public record GuiLayout(String id, String title, int size, ItemStack borderItem, ItemStack routeItem,
-                            ItemStack prevItem, ItemStack nextItem, int prevSlot, int nextSlot, List<Integer> routeSlots) {}
+    public record GuiLayout(String id, String title, int size, ItemStack borderItem,
+                            ItemStack prevItem, ItemStack nextItem, List<Integer> routeSlots,
+                            List<Integer> borderSlots, List<Integer> prevSlots, List<Integer> nextSlots) {}
 }

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
@@ -131,6 +131,11 @@ public class RoutesConfig {
             }
             Integer guiCustomModelData = rs.contains("gui-custom-model-data") ? rs.getInt("gui-custom-model-data") : null;
             String guiItemModel = rs.getString("gui-item-model");
+            String guiItemName = rs.getString("gui-item-name", "&e{route_name}");
+            List<String> guiItemLore = rs.getStringList("gui-item-lore");
+            if (guiItemLore == null || guiItemLore.isEmpty()) {
+                guiItemLore = List.of("&7{route_description}");
+            }
 
             // npc-ids
             Set<Integer> npcIds = new HashSet<>();
@@ -161,6 +166,8 @@ public class RoutesConfig {
                     guiItemMaterial,
                     guiCustomModelData,
                     guiItemModel,
+                    guiItemName,
+                    guiItemLore,
                     npcIds
             );
 

--- a/BetterTradeConvoys/src/main/resources/gui.yml
+++ b/BetterTradeConvoys/src/main/resources/gui.yml
@@ -3,38 +3,21 @@ default-layout: default
 layouts:
   default:
     title: "&8Trade Convoy Routes"
-    size: 54 # Only multiples of 9
-    prev-slot: 37
-    next-slot: 43
+    size: 36 # fallback when layout-pattern is not defined
 
-    # Optional, if omitted default slots will be generated in the inner area.
-    route-slots:
-      - 10
-      - 11
-      - 12
-      - 13
-      - 14
-      - 15
-      - 16
-      - 19
-      - 20
-      - 21
-      - 22
-      - 23
-      - 24
-      - 25
-      - 28
-      - 29
-      - 30
-      - 31
-      - 32
-      - 33
-      - 34
-      - 38
-      - 39
-      - 40
-      - 41
-      - 42
+    layout-pattern:
+      - '111111111'
+      - '100000001'
+      - '100000001'
+      - '211111113'
+
+    # Map any character in layout-pattern to a slot type.
+    # Supported types: BORDER, ROUTE, PREV, NEXT
+    slot-types:
+      '0': ROUTE
+      '1': BORDER
+      '2': PREV
+      '3': NEXT
 
     border-item:
       material: GRAY_STAINED_GLASS_PANE
@@ -42,18 +25,6 @@ layouts:
       item-model: "minecraft:gray_stained_glass_pane"
       custom-model-data: 2001
       lore: []
-
-    route-item:
-      name: "&e{route_name}"
-      lore:
-        - "&7{route_description}"
-        - ""
-        - "&7Input Item: &f{input_item_amount}x {input_item_material}"
-        - "&7Input Money: &f${input_money}"
-        - "&7Output Item: &f{output_item_amount}x {output_item_material}"
-        - "&7Output Money: &f${output_money}"
-        - ""
-        - "&8Route ID: &7{route_id}"
 
     prev-item:
       material: ARROW

--- a/BetterTradeConvoys/src/main/resources/routes.yml
+++ b/BetterTradeConvoys/src/main/resources/routes.yml
@@ -11,6 +11,16 @@ routes:
     gui-item-material: PAPER
     gui-item-model: "minecraft:paper"
     gui-custom-model-data: 1101
+    gui-item-name: "&e{route_name}"
+    gui-item-lore:
+      - "&7{route_description}"
+      - ""
+      - "&7Input Item: &f{input_item_amount}x {input_item_material}"
+      - "&7Input Money: &f${input_money}"
+      - "&7Output Item: &f{output_item_amount}x {output_item_material}"
+      - "&7Output Money: &f${output_money}"
+      - ""
+      - "&8Route ID: &7{route_id}"
 
     # Movement
     speed: 1                    # Citizens speedModifier (1.0 = normal)
@@ -47,6 +57,16 @@ routes:
     gui-item-material: PAPER
     gui-item-model: "minecraft:paper"
     gui-custom-model-data: 1102
+    gui-item-name: "&e{route_name}"
+    gui-item-lore:
+      - "&7{route_description}"
+      - ""
+      - "&7Input Item: &f{input_item_amount}x {input_item_material}"
+      - "&7Input Money: &f${input_money}"
+      - "&7Output Item: &f{output_item_amount}x {output_item_material}"
+      - "&7Output Money: &f${output_money}"
+      - ""
+      - "&8Route ID: &7{route_id}"
 
     speed: 1
     follow-radius: 10
@@ -79,6 +99,16 @@ routes:
     gui-item-material: PAPER
     gui-item-model: "minecraft:paper"
     gui-custom-model-data: 1103
+    gui-item-name: "&e{route_name}"
+    gui-item-lore:
+      - "&7{route_description}"
+      - ""
+      - "&7Input Item: &f{input_item_amount}x {input_item_material}"
+      - "&7Input Money: &f${input_money}"
+      - "&7Output Item: &f{output_item_amount}x {output_item_material}"
+      - "&7Output Money: &f${output_money}"
+      - ""
+      - "&8Route ID: &7{route_id}"
 
     speed: 1
     follow-radius: 10


### PR DESCRIPTION
### Motivation
- Make GUI slot layout fully configurable with an easy-to-read numeric pattern and move per-route item content out of the global GUI template so each route can define its own display name/lore.
- Allow flexible border/route/prev/next placement and multiple prev/next slots while keeping backwards-compatible fallbacks when no pattern is provided.

### Description
- Added `layout-pattern` + `slot-types` support in `gui.yml` so rows like `'111111111' / '100000001' / '100000001' / '211111113'` map characters to slot types (BORDER/ROUTE/PREV/NEXT) and produce `borderSlots`, `routeSlots`, `prevSlots`, and `nextSlots` at load time; fallback to the old `route-slots` / `prev-slot` / `next-slot` behavior when pattern is absent.
- Removed `route-item` from `gui.yml` and added per-route GUI fields `gui-item-name` and `gui-item-lore` (with sensible default lore) in `routes.yml`; those are parsed in `RoutesConfig` and stored on `RouteDefinition`.
- Changed `ConvoyManager` rendering to build route items per-route using `gui-item-*` fields, to place border/route/prev/next items using the computed slot lists, and to support multiple prev/next slots; `applyRouteGuiModel` still applies per-route material/model/custom-model-data.
- Updated `GuiConfig`, `RoutesConfig`, `RouteDefinition`, and `RoutesGuiListener` to handle the new layout mapping and per-route item configuration, and replaced the sample `gui.yml` and `routes.yml` accordingly.

### Testing
- Ran the project's automated tests with `cd BetterTradeConvoys && bash ./gradlew test -q`, which completed successfully.
- Project compiles after the change and the new layout parsing and per-route GUI fields are exercised by the updated sample resources.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08929e969c832b9bfd497848dd43a7)