### PR TITLE
Add command step execution and MiniMessage parsing support

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/language/LanguageManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/language/LanguageManager.java
@@ -1,13 +1,14 @@
 package me.luisgamedev.bettertradeconvoys.language;
 
 import me.clip.placeholderapi.PlaceholderAPI;
-import org.bukkit.ChatColor;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;
 
 import java.io.File;
-import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -16,6 +17,9 @@ public class LanguageManager {
     private final Plugin plugin;
     private YamlConfiguration cfg;
     private String prefix = "";
+    private final MiniMessage miniMessage = MiniMessage.miniMessage();
+    private final LegacyComponentSerializer legacyAmp = LegacyComponentSerializer.legacyAmpersand();
+    private final LegacyComponentSerializer legacySection = LegacyComponentSerializer.legacySection();
 
     public LanguageManager(Plugin plugin) {
         this.plugin = plugin;
@@ -27,7 +31,7 @@ public class LanguageManager {
             plugin.saveResource("language.yml", false);
         }
         cfg = YamlConfiguration.loadConfiguration(f);
-        prefix = colorize(cfg.getString("prefix", "&6[BetterTradeConvoys]&r "));
+        prefix = toLegacy(cfg.getString("prefix", "&6[BetterTradeConvoys]&r "));
     }
 
     public String get(String path) {
@@ -36,8 +40,8 @@ public class LanguageManager {
 
     public String get(OfflinePlayer player, String path) {
         String v = cfg.getString(path);
-        if (v == null) return prefix + ChatColor.RED + "Missing lang key: " + path;
-        return prefix + applyPlaceholders(player, colorize(v));
+        if (v == null) return prefix + "§cMissing lang key: " + path;
+        return prefix + parseToLegacy(player, v);
     }
 
     public String getRaw(String path) {
@@ -47,7 +51,7 @@ public class LanguageManager {
     public String getRaw(OfflinePlayer player, String path) {
         String v = cfg.getString(path);
         if (v == null) return "Missing lang key: " + path;
-        return applyPlaceholders(player, colorize(v));
+        return parseToLegacy(player, v);
     }
 
     public String format(String path, Map<String, Object> placeholders) {
@@ -57,9 +61,8 @@ public class LanguageManager {
     public String format(OfflinePlayer player, String path, Map<String, Object> placeholders) {
         String base = cfg.getString(path);
         if (base == null) base = "Missing lang key: " + path;
-        String colored = colorize(base);
-        String withVars = replacePlaceholders(colored, placeholders);
-        return prefix + applyPlaceholders(player, withVars);
+        String withVars = replacePlaceholders(base, placeholders);
+        return prefix + parseToLegacy(player, withVars);
     }
 
     public String formatRaw(String path, Map<String, Object> placeholders) {
@@ -69,8 +72,7 @@ public class LanguageManager {
     public String formatRaw(OfflinePlayer player, String path, Map<String, Object> placeholders) {
         String base = cfg.getString(path);
         if (base == null) base = "Missing lang key: " + path;
-        String colored = colorize(base);
-        return applyPlaceholders(player, replacePlaceholders(colored, placeholders));
+        return parseToLegacy(player, replacePlaceholders(base, placeholders));
     }
 
     private String applyPlaceholders(OfflinePlayer player, String s) {
@@ -82,8 +84,31 @@ public class LanguageManager {
         }
     }
 
-    private String colorize(String s) {
-        return ChatColor.translateAlternateColorCodes('&', s == null ? "" : s);
+    public String parseToLegacy(OfflinePlayer player, String s) {
+        String parsed = s == null ? "" : s;
+        parsed = applyPlaceholders(player, parsed);
+        return toLegacy(parsed);
+    }
+
+    public String parseToLegacy(String s) {
+        return parseToLegacy(null, s);
+    }
+
+    public Component parseToComponent(OfflinePlayer player, String s) {
+        String parsed = s == null ? "" : s;
+        parsed = applyPlaceholders(player, parsed);
+        String normalized = parsed.replace('§', '&');
+        Component legacy = legacyAmp.deserialize(normalized);
+        String mini = miniMessage.serialize(legacy);
+        return miniMessage.deserialize(mini);
+    }
+
+    private String toLegacy(String s) {
+        if (s == null) return "";
+        String normalized = s.replace('§', '&');
+        Component legacy = legacyAmp.deserialize(normalized);
+        String mini = miniMessage.serialize(legacy);
+        return legacySection.serialize(miniMessage.deserialize(mini));
     }
 
     private String replacePlaceholders(String s, Map<String, Object> placeholders) {

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/CommandStep.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/model/CommandStep.java
@@ -1,0 +1,27 @@
+package me.luisgamedev.bettertradeconvoys.model;
+
+public final class CommandStep implements RouteStep {
+
+    private final String command;
+    private final boolean asConsole;
+    private final String message;
+
+    public CommandStep(String command, boolean asConsole, String message) {
+        this.command = command;
+        this.asConsole = asConsole;
+        this.message = message;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public boolean isAsConsole() {
+        return asConsole;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/ConvoyManager.java
@@ -8,7 +8,6 @@ import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.trait.CurrentLocation;
 import net.citizensnpcs.api.event.DespawnReason;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -224,6 +223,17 @@ public class ConvoyManager {
             sendStepMessage(inst, step);
             handleTradePauseThenNext(npc, inst, rd, idx);
             return;
+        } else if (step instanceof CommandStep c) {
+            runStepCommand(inst, c);
+            sendStepMessage(inst, step);
+            int next = findNextIndex(rd, idx);
+            if (next == -1) {
+                onArrivedAtFinal(npc, inst, rd);
+            } else {
+                stepIndexByInstance.put(inst.getInstanceId(), next);
+                navigateToCurrentStep(npc, inst, rd);
+            }
+            return;
         }
         // For waypoint steps the message is sent once the NPC actually
         // arrives at the location in onNavigationComplete.
@@ -290,7 +300,19 @@ public class ConvoyManager {
         if (msg == null || msg.isEmpty()) return;
         Player owner = Bukkit.getPlayer(inst.getOwner());
         if (owner != null) {
-            owner.sendMessage(ChatColor.translateAlternateColorCodes('&', msg));
+            owner.sendMessage(lang.parseToLegacy(owner, msg));
+        }
+    }
+
+    private void runStepCommand(ConvoyInstance inst, CommandStep step) {
+        String raw = step.getCommand();
+        if (raw == null || raw.isBlank()) return;
+        Player owner = Bukkit.getPlayer(inst.getOwner());
+        String command = lang.parseToLegacy(owner, raw).replace("§", "");
+        if (step.isAsConsole() || owner == null) {
+            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command.startsWith("/") ? command.substring(1) : command);
+        } else {
+            owner.performCommand(command.startsWith("/") ? command.substring(1) : command);
         }
     }
 
@@ -882,9 +904,9 @@ public class ConvoyManager {
         ItemStack item = new ItemStack(route.guiItemMaterial() != null ? route.guiItemMaterial() : Material.PAPER);
         var meta = item.getItemMeta();
         if (meta == null) return item;
-        meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', route.guiItemName()));
+        meta.setDisplayName(lang.parseToLegacy(route.guiItemName()));
         List<String> lore = new ArrayList<>();
-        for (String line : route.guiItemLore()) lore.add(ChatColor.translateAlternateColorCodes('&', line));
+        for (String line : route.guiItemLore()) lore.add(lang.parseToLegacy(line));
         meta.setLore(lore);
         item.setItemMeta(meta);
         return item;

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/GuiConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/GuiConfig.java
@@ -1,7 +1,6 @@
 package me.luisgamedev.bettertradeconvoys.service;
 
 import me.luisgamedev.bettertradeconvoys.BetterTradeConvoys;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
@@ -46,7 +45,7 @@ public class GuiConfig {
             ConfigurationSection ls = sec.getConfigurationSection(key);
             if (ls == null) continue;
             String id = key.toLowerCase(Locale.ROOT);
-            String title = color(ls.getString("title", "Routes"));
+            String title = plugin.language().parseToLegacy(ls.getString("title", "Routes"));
             int size = normalizeSize(ls.getInt("size", 54));
 
             ItemStack border = parseGuiItem(ls.getConfigurationSection("border-item"), Material.GRAY_STAINED_GLASS_PANE, " ", Collections.emptyList());
@@ -95,8 +94,6 @@ public class GuiConfig {
         return layouts.get(defaultLayout);
     }
 
-    private static String color(String s) { return ChatColor.translateAlternateColorCodes('&', s == null ? "" : s); }
-
     private static int normalizeSize(int size) {
         int s = Math.max(9, Math.min(54, size));
         return (s / 9) * 9;
@@ -135,9 +132,9 @@ public class GuiConfig {
         ItemStack item = new ItemStack(mat);
         ItemMeta meta = item.getItemMeta();
         if (meta != null) {
-            meta.setDisplayName(color(name));
+            meta.setDisplayName(plugin.language().parseToLegacy(name));
             List<String> translatedLore = new ArrayList<>();
-            for (String line : lore) translatedLore.add(color(line));
+            for (String line : lore) translatedLore.add(plugin.language().parseToLegacy(line));
             meta.setLore(translatedLore);
             applyCustomModelData(sec, meta);
             applyItemModel(sec, meta);

--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/service/RoutesConfig.java
@@ -62,6 +62,12 @@ public class RoutesConfig {
                         if (map.containsKey("trade")) {
                             String msg = map.containsKey("message") ? String.valueOf(map.get("message")) : null;
                             steps.add(msg == null ? TradeStep.INSTANCE : new TradeStep(msg));
+                        } else if (map.containsKey("command")) {
+                            String command = String.valueOf(map.get("command"));
+                            String executor = map.containsKey("executor") ? String.valueOf(map.get("executor")) : "console";
+                            boolean asConsole = !executor.equalsIgnoreCase("player");
+                            String msg = map.containsKey("message") ? String.valueOf(map.get("message")) : null;
+                            steps.add(new CommandStep(command, asConsole, msg));
                         } else {
                             double x = toDouble(map.get("x"), 0.0);
                             double y = toDouble(map.get("y"), 64.0);

--- a/BetterTradeConvoys/src/main/resources/routes.yml
+++ b/BetterTradeConvoys/src/main/resources/routes.yml
@@ -34,7 +34,8 @@ routes:
     steps:
       - { x: 100.5, y: 64.0, z: -30.5 }   # Start/Spawn & Home-Pos
       - { x: 120.5, y: 64.0, z: -30.5 }
-      - { trade: true, message: "Time to trade." }
+      - { trade: true, message: "<yellow>Time to trade.</yellow>" }
+      - { command: "say %player_name% finished the trade step!", executor: "console", message: "<green>Command step executed.</green>" }
       - { x: 140.5, y: 64.0, z: -15.5, message: "All done, heading back!" }    # Last Waypoint = End & Claim-Spot
 
     # Trade definition
@@ -78,7 +79,8 @@ routes:
     steps:
       - { x: 100.5, y: 64.0, z: -30.5 }   # Start/Spawn & Home-Pos
       - { x: 120.5, y: 64.0, z: -30.5 }
-      - { trade: true, message: "Time to trade." }
+      - { trade: true, message: "<yellow>Time to trade.</yellow>" }
+      - { command: "say %player_name% finished the trade step!", executor: "console", message: "<green>Command step executed.</green>" }
       - { x: 140.5, y: 64.0, z: -15.5, message: "All done, heading back!" }    # Last Waypoint = End & Claim-Spot
 
     trades:
@@ -120,7 +122,8 @@ routes:
     steps:
       - { x: 100.5, y: 64.0, z: -30.5 }   # Start/Spawn & Home-Pos
       - { x: 120.5, y: 64.0, z: -30.5 }
-      - { trade: true, message: "Time to trade." }
+      - { trade: true, message: "<yellow>Time to trade.</yellow>" }
+      - { command: "say %player_name% finished the trade step!", executor: "console", message: "<green>Command step executed.</green>" }
       - { x: 140.5, y: 64.0, z: -15.5, message: "All done, heading back!" }    # Last Waypoint = End & Claim-Spot
 
     trades:


### PR DESCRIPTION
### Motivation
- Provide a new `command` step type so route steps can execute arbitrary commands as either the player or the console and advance the route automatically.  
- Allow placeholders to be expanded inside command strings so commands can reference runtime data (e.g. player name).  
- Add MiniMessage-compatible parsing across the plugin so route messages, GUI titles/names/lore and language strings can use MiniMessage syntax while retaining legacy ampersand/section support.

### Description
- Added a new `CommandStep` class implementing `RouteStep` with `command`, `executor` (player/console) and optional `message` fields (file: `model/CommandStep.java`).
- Extended `RoutesConfig` to parse `steps` entries with `command`, optional `executor` (defaults to `console`) and optional `message` and create `CommandStep` instances when present (file: `service/RoutesConfig.java`).
- Integrated command execution into the convoy flow in `ConvoyManager` by adding `runStepCommand` which expands placeholders via the language manager, dispatches the command to console or has the player perform it, then advances the route (file: `service/ConvoyManager.java`).
- Reworked `LanguageManager` to add MiniMessage support and new helper methods `parseToLegacy(...)` and `parseToComponent(...)` so legacy color codes and MiniMessage are both supported and placeholders are applied before parsing (file: `language/LanguageManager.java`).
- Updated GUI text construction to use the new language parsing so titles, item names and lore support MiniMessage (file: `service/GuiConfig.java` and `service/ConvoyManager.java`).
- Updated example `routes.yml` to demonstrate MiniMessage-formatted step messages and a `command` step entry (file: `src/main/resources/routes.yml`).

### Testing
- Attempted an initial build with `./gradlew build -x test` which failed in this environment due to `gradlew` not being executable.  
- Successfully ran an automated build with `bash ./gradlew build -x test`, which completed and produced a successful compile/assemble (`BUILD SUCCESSFUL`).  
- No automated unit tests exist in the project; validation was limited to a successful Gradle build (compilation and resource processing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08972d29f4832b8a87eb6065046e78)