### PR TITLE
Fix MiniMessage parsing for config text

### DIFF
--- a/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/language/LanguageManager.java
+++ b/BetterTradeConvoys/src/main/java/me/luisgamedev/bettertradeconvoys/language/LanguageManager.java
@@ -97,18 +97,23 @@ public class LanguageManager {
     public Component parseToComponent(OfflinePlayer player, String s) {
         String parsed = s == null ? "" : s;
         parsed = applyPlaceholders(player, parsed);
-        String normalized = parsed.replace('§', '&');
-        Component legacy = legacyAmp.deserialize(normalized);
-        String mini = miniMessage.serialize(legacy);
-        return miniMessage.deserialize(mini);
+        return parseFormatting(parsed);
     }
 
     private String toLegacy(String s) {
         if (s == null) return "";
+        return legacySection.serialize(parseFormatting(s));
+    }
+
+    private Component parseFormatting(String s) {
         String normalized = s.replace('§', '&');
-        Component legacy = legacyAmp.deserialize(normalized);
-        String mini = miniMessage.serialize(legacy);
-        return legacySection.serialize(miniMessage.deserialize(mini));
+        try {
+            Component miniParsed = miniMessage.deserialize(normalized);
+            String legacy = legacySection.serialize(miniParsed).replace('§', '&');
+            return legacyAmp.deserialize(legacy);
+        } catch (RuntimeException ignored) {
+            return legacyAmp.deserialize(normalized);
+        }
     }
 
     private String replacePlaceholders(String s, Map<String, Object> placeholders) {


### PR DESCRIPTION
### Motivation
- Config messages containing MiniMessage tags (e.g. `<yellow>Time to trade.</yellow>`) were displayed literally because the formatting pipeline treated them as legacy/plain text first. 
- The goal is to support MiniMessage in config strings while preserving existing legacy `&`/`§` color support and placeholder expansion.

### Description
- Reworked `LanguageManager` so `parseToComponent` delegates to a new `parseFormatting` helper that attempts MiniMessage deserialization first. 
- Updated `toLegacy` to serialize through `parseFormatting` so Bukkit `sendMessage(String)` callers receive legacy-colored output generated from MiniMessage when available. 
- Implemented `parseFormatting(String)` which tries `miniMessage.deserialize(...)` then converts to legacy output, and falls back to legacy ampersand/section parsing on failure. 
- Kept existing placeholder expansion and the public `parseToLegacy`/`format` APIs unchanged.

### Testing
- Built the project with `./gradlew build` and the build completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c8a923bbc832baf0a8409aac53383)